### PR TITLE
Add Cadastros submenu

### DIFF
--- a/frontend/src/app/components/layout/sidebar/sidebar.component.html
+++ b/frontend/src/app/components/layout/sidebar/sidebar.component.html
@@ -37,6 +37,22 @@
       </li>
     </ul>
 
+    <div class="menu-section">
+      <div class="section-title">Cadastros</div>
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link" routerLink="/admin/turmas" routerLinkActive="active">
+            <i class="fas fa-chalkboard"></i> Turmas
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" routerLink="/admin/alunos" routerLinkActive="active">
+            <i class="fas fa-user-graduate"></i> Alunos
+          </a>
+        </li>
+      </ul>
+    </div>
+
     <!-- Rodapé da sidebar (opcional) -->
     <div class="p-3 text-center border-top border-warning border-opacity-50 mt-auto">
       <small class="text-muted">Sentinel v1.0</small>

--- a/frontend/src/app/components/layout/sidebar/sidebar.component.ts
+++ b/frontend/src/app/components/layout/sidebar/sidebar.component.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
+import { RouterLink, RouterLinkActive } from '@angular/router';
 
 @Component({
   selector: 'app-sidebar',
-  imports: [],
+  imports: [RouterLink, RouterLinkActive],
   templateUrl: './sidebar.component.html',
   styleUrl: './sidebar.component.css'
 })


### PR DESCRIPTION
## Summary
- add "Cadastros" section in sidebar with links to Turmas and Alunos
- enable RouterLink directives in sidebar component

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685457f1256883208141df9f9a132ac5