### PR TITLE
Fix datepicker provider import

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -5,7 +5,8 @@ import { routes } from './app.routes';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideHttpClient } from '@angular/common/http';
 import { provideNativeDateAdapter } from '@angular/material/core';
-import { provideMatDatepicker } from '@angular/material/datepicker';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { importProvidersFrom } from '@angular/core';
 
 
 
@@ -15,7 +16,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideAnimations(),
     provideHttpClient(),
-    provideMatDatepicker(),
+    importProvidersFrom(MatDatepickerModule),
     provideNativeDateAdapter()
   ]
 };

--- a/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.ts
+++ b/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.ts
@@ -58,7 +58,6 @@ export class AlunosdetailsComponent {
     '',
     '',
     '',
-    undefined,
     undefined
   );
   router = inject(ActivatedRoute);


### PR DESCRIPTION
## Summary
- replace `provideMatDatepicker` with `MatDatepickerModule` provider
- adjust constructor call for `Aluno` model

## Testing
- `npm run build` *(fails: bundle exceeds budget)*

------
https://chatgpt.com/codex/tasks/task_e_68555e6ca8ec8320aef24368cdb9b21e