### PR TITLE
Add file upload support for students

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .DS_Store
 .idea/
 .vscode/
+backend/uploads/

--- a/backend/src/main/java/com/sentinel/backend/controller/AlunosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/AlunosController.java
@@ -11,11 +11,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.sentinel.backend.entity.Aluno;
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.service.AlunoService;
+import com.sentinel.backend.service.AlunoDocumentoService;
 
 @RestController
 @RequestMapping("/alunos")
@@ -24,6 +27,9 @@ public class AlunosController {
 
     @Autowired
     private AlunoService as;
+
+    @Autowired
+    private AlunoDocumentoService documentoService;
 
     @GetMapping("/findAll")
     public Iterable<Aluno> listar() {
@@ -52,6 +58,15 @@ public class AlunosController {
             return new ResponseEntity<>(aluno, HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @PostMapping("/upload/{id}")
+    public ResponseEntity<?> upload(@PathVariable Long id, @RequestParam("files") MultipartFile[] files) {
+        try {
+            return new ResponseEntity<>(documentoService.salvar(id, files), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
     }
 }

--- a/backend/src/main/java/com/sentinel/backend/entity/Aluno.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/Aluno.java
@@ -1,6 +1,7 @@
 package com.sentinel.backend.entity;
 
 import java.util.Date;
+import java.util.List;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,7 +10,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Table;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -63,4 +67,8 @@ public class Aluno {
     @ManyToOne(optional = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "turma_id", referencedColumnName = "id")
     private Turma turma;
+
+    @OneToMany(mappedBy = "aluno", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonIgnore
+    private List<AlunoDocumento> documentos;
 }

--- a/backend/src/main/java/com/sentinel/backend/entity/AlunoDocumento.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/AlunoDocumento.java
@@ -1,0 +1,31 @@
+package com.sentinel.backend.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "aluno_documentos")
+@Getter
+@Setter
+public class AlunoDocumento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String fileName;
+
+    private String filePath;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "aluno_id")
+    private Aluno aluno;
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/AlunoDocumentoRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/AlunoDocumentoRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.AlunoDocumento;
+
+public interface AlunoDocumentoRepository extends JpaRepository<AlunoDocumento, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/service/AlunoDocumentoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/AlunoDocumentoService.java
@@ -1,0 +1,51 @@
+package com.sentinel.backend.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.sentinel.backend.entity.Aluno;
+import com.sentinel.backend.entity.AlunoDocumento;
+import com.sentinel.backend.repository.AlunoDocumentoRepository;
+import com.sentinel.backend.repository.AlunoRepository;
+
+@Service
+public class AlunoDocumentoService {
+
+    private final Path root = Paths.get("uploads");
+
+    @Autowired
+    private AlunoRepository alunoRepository;
+
+    @Autowired
+    private AlunoDocumentoRepository documentoRepository;
+
+    public List<AlunoDocumento> salvar(Long alunoId, MultipartFile[] files) throws IOException {
+        Aluno aluno = alunoRepository.findById(alunoId).orElseThrow();
+
+        Files.createDirectories(root);
+
+        List<AlunoDocumento> salvos = new ArrayList<>();
+        for (MultipartFile file : files) {
+            String filename = UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
+            Path destination = root.resolve(filename);
+            Files.copy(file.getInputStream(), destination, StandardCopyOption.REPLACE_EXISTING);
+
+            AlunoDocumento doc = new AlunoDocumento();
+            doc.setFileName(file.getOriginalFilename());
+            doc.setFilePath(destination.toString());
+            doc.setAluno(aluno);
+            salvos.add(documentoRepository.save(doc));
+        }
+        return salvos;
+    }
+}

--- a/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.html
+++ b/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.html
@@ -287,6 +287,9 @@
                 </div>
               </div>
 
+              <h6 class="mb-3">Documentos</h6>
+              <p-fileupload #fileUploader name="files" [url]="uploadUrl" [multiple]="true" [disabled]="!aluno.id" mode="advanced" (onUpload)="onUpload()"></p-fileupload>
+
               <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-3">
                 <button type="button" class="btn btn-warning btn-rounded" mdbRipple (click)="save()">
                   <i class="fas fa-save me-2"></i>Salvar

--- a/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.ts
+++ b/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
@@ -6,6 +6,8 @@ import {ChangeDetectionStrategy} from '@angular/core';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 import {MatInputModule} from '@angular/material/input';
 import {MatFormFieldModule} from '@angular/material/form-field';
+import { FileUploadModule } from 'primeng/fileupload';
+import { FileUpload } from 'primeng/fileupload';
 import { ActivatedRoute, Router } from '@angular/router';
 import Swal from 'sweetalert2';
 import { Aluno } from '../../../models/aluno';
@@ -14,7 +16,7 @@ import { AlunosService } from '../../../services/alunos.service';
 @Component({
   selector: 'app-alunosdetails',
   standalone: true,
-  imports: [CommonModule, MdbFormsModule, FormsModule, MatDatepickerModule, MatFormFieldModule, MatInputModule, MatDatepickerModule],
+  imports: [CommonModule, MdbFormsModule, FormsModule, MatDatepickerModule, MatFormFieldModule, MatInputModule, MatDatepickerModule, FileUploadModule],
   templateUrl: './alunosdetails.component.html',
   styleUrl: './alunosdetails.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -64,8 +66,23 @@ export class AlunosdetailsComponent {
   router2 = inject(Router);
   alunosService = inject(AlunosService);
 
+  @ViewChild('fileUploader') fileUploader?: FileUpload;
+
   generos = ['Masculino', 'Feminino', 'Não Binário', 'Prefere não informar'];
   parentescos = ['Pai', 'Mãe', 'Responsável Legal', 'Avô/Avó', 'Tio/Tia'];
+
+  get uploadUrl(): string {
+    return `http://localhost:8080/alunos/upload/${this.aluno.id}`;
+  }
+
+  onUpload() {
+    Swal.fire({
+      title: 'Arquivos enviados com sucesso!',
+      icon: 'success',
+      confirmButtonText: 'Ok'
+    });
+    this.fileUploader?.clear();
+  }
 
   constructor() {
     const id = this.router.snapshot.params['id'];

--- a/frontend/src/app/services/alunos.service.ts
+++ b/frontend/src/app/services/alunos.service.ts
@@ -27,6 +27,12 @@ export class AlunosService {
     return this.http.put<string>(this.API + '/update', aluno, { responseType: 'text' as 'json' });
   }
 
+  upload(id: number, files: File[]): Observable<any> {
+    const formData = new FormData();
+    files.forEach(f => formData.append('files', f));
+    return this.http.post(this.API + '/upload/' + id, formData);
+  }
+
   findById(id: number): Observable<Aluno> {
     return this.http.get<Aluno>(this.API + '/findById/' + id);
   }


### PR DESCRIPTION
## Summary
- create `AlunoDocumento` entity and persistence layer
- enable relation between `Aluno` and `AlunoDocumento`
- implement `AlunoDocumentoService` with local storage
- expose `/alunos/upload/{id}` endpoint
- integrate PrimeNG FileUpload in aluno form
- add Angular service helper
- ignore backend `uploads` folder

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855649b5a8883208ef35a3b7034857a