### PR TITLE
Add templated file upload

### DIFF
--- a/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.html
+++ b/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.html
@@ -288,7 +288,61 @@
               </div>
 
               <h6 class="mb-3">Documentos</h6>
-              <p-fileupload #fileUploader name="files" [url]="uploadUrl" [multiple]="true" [disabled]="!aluno.id" mode="advanced" (onUpload)="onUpload()"></p-fileupload>
+              <p-toast></p-toast>
+              <p-fileupload #fileUploader name="files" [url]="uploadUrl" [multiple]="true" [disabled]="!aluno.id"
+                            accept="image/*" maxFileSize="1000000" (onUpload)="onTemplatedUpload()" (onSelect)="onSelectedFiles($event)">
+                <ng-template #header let-files let-chooseCallback="chooseCallback" let-clearCallback="clearCallback" let-uploadCallback="uploadCallback">
+                    <div class="flex flex-wrap justify-between items-center flex-1 gap-4">
+                        <div class="flex gap-2">
+                            <p-button (onClick)="choose($event, chooseCallback)" icon="pi pi-images" [rounded]="true" [outlined]="true"></p-button>
+                            <p-button (onClick)="uploadEvent(uploadCallback)" icon="pi pi-cloud-upload" [rounded]="true" [outlined]="true" severity="success" [disabled]="!files || files.length === 0"></p-button>
+                            <p-button (onClick)="clearCallback()" icon="pi pi-times" [rounded]="true" [outlined]="true" severity="danger" [disabled]="!files || files.length === 0"></p-button>
+                        </div>
+                        <p-progressbar [value]="totalSizePercent" [showValue]="false" class="w-full" styleClass="md:w-20rem h-1 w-full md:ml-auto">
+                            <span class="whitespace-nowrap">{{ totalSize }}B / 1Mb</span>
+                        </p-progressbar>
+                    </div>
+                </ng-template>
+                <ng-template #content let-files let-uploadedFiles="uploadedFiles" let-removeFileCallback="removeFileCallback" let-removeUploadedFileCallback="removeUploadedFileCallback">
+                    <div class="flex flex-col gap-8 pt-4">
+                        <div *ngIf="files?.length > 0">
+                            <h5>Pending</h5>
+                            <div class="flex flex-wrap gap-4">
+                                <div *ngFor="let file of files; let i = index" class="p-8 rounded-border flex flex-col border border-surface items-center gap-4">
+                                    <div>
+                                        <img role="presentation" [alt]="file.name" [src]="file.objectURL" width="100" height="50" />
+                                    </div>
+                                    <span class="font-semibold text-ellipsis max-w-60 whitespace-nowrap overflow-hidden">{{ file.name }}</span>
+                                    <div>{{ formatSize(file.size) }}</div>
+                                    <p-badge value="Pending" severity="warn"></p-badge>
+                                    <p-button icon="pi pi-times" (click)="onRemoveTemplatingFile($event, file, removeFileCallback, index)" [outlined]="true" [rounded]="true" severity="danger"></p-button>
+                                </div>
+                            </div>
+                        </div>
+                        <div *ngIf="uploadedFiles?.length > 0">
+                            <h5>Completed</h5>
+                            <div class="flex flex-wrap gap-4">
+                                <div *ngFor="let file of uploadedFiles; let i = index" class="card m-0 px-12 flex flex-col border border-surface items-center gap-4">
+                                    <div>
+                                        <img role="presentation" [alt]="file.name" [src]="file.objectURL" width="100" height="50" />
+                                    </div>
+                                    <span class="font-semibold text-ellipsis max-w-60 whitespace-nowrap overflow-hidden">{{ file.name }}</span>
+                                    <div>{{ formatSize(file.size) }}</div>
+                                    <p-badge value="Completed" class="mt-4" severity="success"></p-badge>
+                                    <p-button icon="pi pi-times" (onClick)="removeUploadedFileCallback(index)" [outlined]="true" [rounded]="true" severity="danger"></p-button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </ng-template>
+                <ng-template #file></ng-template>
+                <ng-template #empty>
+                    <div class="flex items-center justify-center flex-col">
+                        <i class="pi pi-cloud-upload !border-2 !rounded-full !p-8 !text-4xl !text-muted-color"></i>
+                        <p class="mt-6 mb-0">Drag and drop files to here to upload.</p>
+                    </div>
+                </ng-template>
+              </p-fileupload>
 
               <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-3">
                 <button type="button" class="btn btn-warning btn-rounded" mdbRipple (click)="save()">


### PR DESCRIPTION
## Summary
- implement PrimeNG templated file upload in aluno details
- handle file upload events with message toast and progress

## Testing
- `npx ng test --watch=false` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68556acad4888320b8e9593a1c6dbf89