### PR TITLE
Implement CEP lookup and responsible helpers

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -17,6 +17,6 @@ export const appConfig: ApplicationConfig = {
     provideAnimations(),
     provideHttpClient(),
     importProvidersFrom(MatDatepickerModule),
-    provideNativeDateAdapter()
+    provideNativeDateAdapter('pt-BR')
   ]
 };

--- a/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.html
+++ b/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.html
@@ -55,7 +55,7 @@
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="cep" class="form-control" [(ngModel)]="aluno.cep" />
+                    <input mdbInput type="text" id="cep" class="form-control" [(ngModel)]="aluno.cep" (blur)="buscarCepAluno()" />
                     <label mdbLabel class="form-label" for="cep">CEP</label>
                   </mdb-form-control>
                 </div>
@@ -119,6 +119,10 @@
                   </mdb-form-control>
                 </div>
                 <div class="col-md-6 mb-3">
+                  <div class="form-check mb-2">
+                    <input class="form-check-input" type="checkbox" id="mesmo_tel1" [(ngModel)]="mesmoTelefoneResp1" (change)="atualizarTelefoneResp1()" />
+                    <label class="form-check-label" for="mesmo_tel1">Mesmo telefone que aluno</label>
+                  </div>
                   <mdb-form-control>
                     <input mdbInput type="text" id="telefone_resp1" class="form-control" [(ngModel)]="aluno.telefone_resp1" />
                     <label mdbLabel class="form-label" for="telefone_resp1">Telefone</label>
@@ -127,6 +131,10 @@
               </div>
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
+                  <div class="form-check mb-2">
+                    <input class="form-check-input" type="checkbox" id="mesmo_email1" [(ngModel)]="mesmoEmailResp1" (change)="atualizarEmailResp1()" />
+                    <label class="form-check-label" for="mesmo_email1">Mesmo email que aluno</label>
+                  </div>
                   <mdb-form-control>
                     <input mdbInput type="text" id="email_resp1" class="form-control" [(ngModel)]="aluno.email_resp1" />
                     <label mdbLabel class="form-label" for="email_resp1">Email</label>
@@ -141,8 +149,12 @@
               </div>
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
+                  <div class="form-check mb-2">
+                    <input class="form-check-input" type="checkbox" id="mesmo_end1" [(ngModel)]="mesmoEnderecoResp1" (change)="atualizarEnderecoResp1()" />
+                    <label class="form-check-label" for="mesmo_end1">Mesmo endereço que aluno</label>
+                  </div>
                   <mdb-form-control>
-                    <input mdbInput type="text" id="cep_resp1" class="form-control" [(ngModel)]="aluno.cep_resp1" />
+                    <input mdbInput type="text" id="cep_resp1" class="form-control" [(ngModel)]="aluno.cep_resp1" (blur)="buscarCepResp1()" />
                     <label mdbLabel class="form-label" for="cep_resp1">CEP</label>
                   </mdb-form-control>
                 </div>
@@ -199,45 +211,61 @@
               </div>
 
               <!-- Dados do responsável 2 -->
+              <div class="form-check mb-2">
+                <input class="form-check-input" type="checkbox" id="sem_resp2" [(ngModel)]="semResponsavel2" (change)="toggleResponsavel2()" />
+                <label class="form-check-label" for="sem_resp2">Não possui responsavel 2</label>
+              </div>
               <h6 class="mb-3">Dados Responsavel 2</h6>
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="nome_resp2" class="form-control" [(ngModel)]="aluno.nome_resp2" />
+                    <input mdbInput type="text" id="nome_resp2" class="form-control" [(ngModel)]="aluno.nome_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="nome_resp2">Nome Responsável</label>
                   </mdb-form-control>
                 </div>
                 <div class="col-md-6 mb-3">
+                  <div class="form-check mb-2">
+                    <input class="form-check-input" type="checkbox" id="mesmo_tel2" [(ngModel)]="mesmoTelefoneResp2" (change)="atualizarTelefoneResp2()" />
+                    <label class="form-check-label" for="mesmo_tel2">Mesmo telefone que aluno</label>
+                  </div>
                   <mdb-form-control>
-                    <input mdbInput type="text" id="telefone_resp2" class="form-control" [(ngModel)]="aluno.telefone_resp2" />
+                    <input mdbInput type="text" id="telefone_resp2" class="form-control" [(ngModel)]="aluno.telefone_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="telefone_resp2">Telefone</label>
                   </mdb-form-control>
                 </div>
               </div>
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
+                  <div class="form-check mb-2">
+                    <input class="form-check-input" type="checkbox" id="mesmo_email2" [(ngModel)]="mesmoEmailResp2" (change)="atualizarEmailResp2()" />
+                    <label class="form-check-label" for="mesmo_email2">Mesmo email que aluno</label>
+                  </div>
                   <mdb-form-control>
-                    <input mdbInput type="text" id="email_resp2" class="form-control" [(ngModel)]="aluno.email_resp2" />
+                    <input mdbInput type="text" id="email_resp2" class="form-control" [(ngModel)]="aluno.email_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="email_resp2">Email</label>
                   </mdb-form-control>
                 </div>
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="cpf_resp2" class="form-control" [(ngModel)]="aluno.cpf_resp2" />
+                    <input mdbInput type="text" id="cpf_resp2" class="form-control" [(ngModel)]="aluno.cpf_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="cpf_resp2">CPF</label>
                   </mdb-form-control>
                 </div>
               </div>
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
+                  <div class="form-check mb-2">
+                    <input class="form-check-input" type="checkbox" id="mesmo_end2" [(ngModel)]="mesmoEnderecoResp2" (change)="atualizarEnderecoResp2()" />
+                    <label class="form-check-label" for="mesmo_end2">Mesmo endereço que aluno</label>
+                  </div>
                   <mdb-form-control>
-                    <input mdbInput type="text" id="cep_resp2" class="form-control" [(ngModel)]="aluno.cep_resp2" />
+                    <input mdbInput type="text" id="cep_resp2" class="form-control" [(ngModel)]="aluno.cep_resp2" (blur)="buscarCepResp2()" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="cep_resp2">CEP</label>
                   </mdb-form-control>
                 </div>
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="rua_resp2" class="form-control" [(ngModel)]="aluno.rua_resp2" />
+                    <input mdbInput type="text" id="rua_resp2" class="form-control" [(ngModel)]="aluno.rua_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="rua_resp2">Rua</label>
                   </mdb-form-control>
                 </div>
@@ -245,13 +273,13 @@
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="numero_resp2" class="form-control" [(ngModel)]="aluno.numero_resp2" />
+                    <input mdbInput type="text" id="numero_resp2" class="form-control" [(ngModel)]="aluno.numero_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="numero_resp2">Número</label>
                   </mdb-form-control>
                 </div>
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="complemento_resp2" class="form-control" [(ngModel)]="aluno.complemento_resp2" />
+                    <input mdbInput type="text" id="complemento_resp2" class="form-control" [(ngModel)]="aluno.complemento_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="complemento_resp2">Complemento</label>
                   </mdb-form-control>
                 </div>
@@ -259,13 +287,13 @@
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="bairro_resp2" class="form-control" [(ngModel)]="aluno.bairro_resp2" />
+                    <input mdbInput type="text" id="bairro_resp2" class="form-control" [(ngModel)]="aluno.bairro_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="bairro_resp2">Bairro</label>
                   </mdb-form-control>
                 </div>
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="cidade_resp2" class="form-control" [(ngModel)]="aluno.cidade_resp2" />
+                    <input mdbInput type="text" id="cidade_resp2" class="form-control" [(ngModel)]="aluno.cidade_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="cidade_resp2">Cidade</label>
                   </mdb-form-control>
                 </div>
@@ -273,13 +301,13 @@
               <div class="row mb-4">
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" id="estado_resp2" class="form-control" [(ngModel)]="aluno.estado_resp2" />
+                    <input mdbInput type="text" id="estado_resp2" class="form-control" [(ngModel)]="aluno.estado_resp2" [disabled]="semResponsavel2" />
                     <label mdbLabel class="form-label" for="estado_resp2">Estado</label>
                   </mdb-form-control>
                 </div>
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <select mdbInput class="form-control" [(ngModel)]="aluno.parentesco_resp2">
+                    <select mdbInput class="form-control" [(ngModel)]="aluno.parentesco_resp2" [disabled]="semResponsavel2">
                       <option *ngFor="let p of parentescos" [value]="p">{{ p }}</option>
                     </select>
                     <label mdbLabel class="form-label">Parentesco</label>

--- a/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.ts
+++ b/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.ts
@@ -2,20 +2,35 @@ import { Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
-import {MatDatepickerModule} from '@angular/material/datepicker';
-import {MatInputModule} from '@angular/material/input';
-import {MatFormFieldModule} from '@angular/material/form-field';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { ActivatedRoute, Router } from '@angular/router';
 import Swal from 'sweetalert2';
 import { Aluno } from '../../../models/aluno';
 import { AlunosService } from '../../../services/alunos.service';
+import { HttpClient } from '@angular/common/http';
+import { MAT_DATE_FORMATS } from '@angular/material/core';
+
+export const MY_DATE_FORMATS = {
+  parse: {
+    dateInput: 'DD/MM/YYYY'
+  },
+  display: {
+    dateInput: 'DD/MM/YYYY',
+    monthYearLabel: 'MM/YYYY',
+    dateA11yLabel: 'DD/MM/YYYY',
+    monthYearA11yLabel: 'MM/YYYY'
+  }
+};
 
 @Component({
   selector: 'app-alunosdetails',
   standalone: true,
   imports: [CommonModule, MdbFormsModule, FormsModule, MatDatepickerModule, MatFormFieldModule, MatInputModule, MatDatepickerModule],
   templateUrl: './alunosdetails.component.html',
-  styleUrl: './alunosdetails.component.css'
+  styleUrl: './alunosdetails.component.css',
+  providers: [{ provide: MAT_DATE_FORMATS, useValue: MY_DATE_FORMATS }]
 })
 export class AlunosdetailsComponent {
   aluno: Aluno = new Aluno(
@@ -61,9 +76,123 @@ export class AlunosdetailsComponent {
   router = inject(ActivatedRoute);
   router2 = inject(Router);
   alunosService = inject(AlunosService);
+  http = inject(HttpClient);
+
+  mesmoEnderecoResp1 = false;
+  mesmoTelefoneResp1 = false;
+  mesmoEmailResp1 = false;
+
+  mesmoEnderecoResp2 = false;
+  mesmoTelefoneResp2 = false;
+  mesmoEmailResp2 = false;
+
+  semResponsavel2 = false;
 
   generos = ['Masculino', 'Feminino', 'Não Binário', 'Prefere não informar'];
   parentescos = ['Pai', 'Mãe', 'Responsável Legal', 'Avô/Avó', 'Tio/Tia'];
+
+  buscarCepAluno() {
+    this.buscarCep(this.aluno.cep, 'aluno');
+  }
+
+  buscarCepResp1() {
+    this.buscarCep(this.aluno.cep_resp1, 'resp1');
+  }
+
+  buscarCepResp2() {
+    this.buscarCep(this.aluno.cep_resp2, 'resp2');
+  }
+
+  private buscarCep(cep: string, alvo: 'aluno' | 'resp1' | 'resp2') {
+    const cepLimpo = cep?.replace(/\D/g, '');
+    if (cepLimpo && cepLimpo.length === 8) {
+      this.http.get<any>(`https://viacep.com.br/ws/${cepLimpo}/json/`).subscribe(d => {
+        if (!d.erro) {
+          if (alvo === 'aluno') {
+            this.aluno.rua = d.logradouro;
+            this.aluno.bairro = d.bairro;
+            this.aluno.cidade = d.localidade;
+            this.aluno.estado = d.uf;
+          } else if (alvo === 'resp1') {
+            this.aluno.rua_resp1 = d.logradouro;
+            this.aluno.bairro_resp1 = d.bairro;
+            this.aluno.cidade_resp1 = d.localidade;
+            this.aluno.estado_resp1 = d.uf;
+          } else {
+            this.aluno.rua_resp2 = d.logradouro;
+            this.aluno.bairro_resp2 = d.bairro;
+            this.aluno.cidade_resp2 = d.localidade;
+            this.aluno.estado_resp2 = d.uf;
+          }
+        }
+      });
+    }
+  }
+
+  atualizarEnderecoResp1() {
+    if (this.mesmoEnderecoResp1) {
+      this.aluno.cep_resp1 = this.aluno.cep;
+      this.aluno.rua_resp1 = this.aluno.rua;
+      this.aluno.numero_resp1 = this.aluno.numero;
+      this.aluno.complemento_resp1 = this.aluno.complemento;
+      this.aluno.bairro_resp1 = this.aluno.bairro;
+      this.aluno.cidade_resp1 = this.aluno.cidade;
+      this.aluno.estado_resp1 = this.aluno.estado;
+    }
+  }
+
+  atualizarTelefoneResp1() {
+    if (this.mesmoTelefoneResp1) {
+      this.aluno.telefone_resp1 = this.aluno.telefone;
+    }
+  }
+
+  atualizarEmailResp1() {
+    if (this.mesmoEmailResp1) {
+      this.aluno.email_resp1 = this.aluno.email;
+    }
+  }
+
+  atualizarEnderecoResp2() {
+    if (this.mesmoEnderecoResp2) {
+      this.aluno.cep_resp2 = this.aluno.cep;
+      this.aluno.rua_resp2 = this.aluno.rua;
+      this.aluno.numero_resp2 = this.aluno.numero;
+      this.aluno.complemento_resp2 = this.aluno.complemento;
+      this.aluno.bairro_resp2 = this.aluno.bairro;
+      this.aluno.cidade_resp2 = this.aluno.cidade;
+      this.aluno.estado_resp2 = this.aluno.estado;
+    }
+  }
+
+  atualizarTelefoneResp2() {
+    if (this.mesmoTelefoneResp2) {
+      this.aluno.telefone_resp2 = this.aluno.telefone;
+    }
+  }
+
+  atualizarEmailResp2() {
+    if (this.mesmoEmailResp2) {
+      this.aluno.email_resp2 = this.aluno.email;
+    }
+  }
+
+  toggleResponsavel2() {
+    if (this.semResponsavel2) {
+      this.aluno.nome_resp2 = '';
+      this.aluno.telefone_resp2 = '';
+      this.aluno.email_resp2 = '';
+      this.aluno.cpf_resp2 = '';
+      this.aluno.cep_resp2 = '';
+      this.aluno.rua_resp2 = '';
+      this.aluno.numero_resp2 = '';
+      this.aluno.complemento_resp2 = '';
+      this.aluno.bairro_resp2 = '';
+      this.aluno.cidade_resp2 = '';
+      this.aluno.estado_resp2 = '';
+      this.aluno.parentesco_resp2 = '';
+    }
+  }
 
   constructor() {
     const id = this.router.snapshot.params['id'];


### PR DESCRIPTION
## Summary
- set date locale to pt-BR
- format material datepicker to DD/MM/YYYY
- add CEP lookup and helper checkboxes for responsible addresses, phones and emails
- support disabling responsible 2 fields when not provided

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557cfd12188320b9ac00094eb382e3