### PR TITLE
Fix Material date locale configuration

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -4,7 +4,7 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideHttpClient } from '@angular/common/http';
-import { provideNativeDateAdapter } from '@angular/material/core';
+import { provideNativeDateAdapter, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { importProvidersFrom } from '@angular/core';
 
@@ -17,6 +17,7 @@ export const appConfig: ApplicationConfig = {
     provideAnimations(),
     provideHttpClient(),
     importProvidersFrom(MatDatepickerModule),
-    provideNativeDateAdapter('pt-BR')
+    provideNativeDateAdapter(),
+    { provide: MAT_DATE_LOCALE, useValue: 'pt-BR' }
   ]
 };


### PR DESCRIPTION
## Summary
- fix the call to `provideNativeDateAdapter` and configure the locale via `MAT_DATE_LOCALE`

## Testing
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_685582f5b3cc8320a67c9a9c0ae630b6