### PR TITLE
Improve error message when student save fails

### DIFF
--- a/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.ts
+++ b/frontend/src/app/components/alunos/alunosdetails/alunosdetails.component.ts
@@ -249,9 +249,13 @@ export class AlunosdetailsComponent {
         },
         error: (erro) => {
           console.error('Erro completo:', erro);
+          let mensagem = `Status: ${erro.status} - ${erro.statusText || 'Sem mensagem'}`;
+          if (erro.error && typeof erro.error === 'object' && erro.error.mensagem) {
+            mensagem = erro.error.mensagem;
+          }
           Swal.fire({
             title: 'Ocorreu um erro!',
-            text: `Status: ${erro.status} - ${erro.statusText || 'Sem mensagem'}`,
+            text: mensagem,
             icon: 'error',
             confirmButtonText: 'Ok'
           });


### PR DESCRIPTION
## Summary
- show server-provided messages when saving a student fails

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855a0659eb88320a24796e2309181a6