### PR TITLE
Ajusta menu lateral

### DIFF
--- a/frontend/src/app/components/layout/sidebar/sidebar.component.html
+++ b/frontend/src/app/components/layout/sidebar/sidebar.component.html
@@ -12,8 +12,8 @@
       </a>
     </div>
 
-    <!-- Menu de navegação -->
-    <ul class="navbar-nav flex-grow-1">
+  <!-- Menu de navegação -->
+  <ul class="navbar-nav">
       <li class="nav-item">
         <a class="nav-link active" aria-current="page" href="#">
           <i class="fas fa-home"></i> Home
@@ -23,18 +23,18 @@
 
     <div class="menu-section">
       <div class="section-title text-center">Cadastros</div>
-      <ul class="navbar-nav">
-        <li class="nav-item">
-          <a class="nav-link" routerLink="/admin/turmas" routerLinkActive="active">
-            <i class="fas fa-chalkboard"></i> Turmas
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" routerLink="/admin/alunos" routerLinkActive="active">
-            <i class="fas fa-user-graduate"></i> Alunos
-          </a>
-        </li>
-      </ul>
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link" routerLink="/admin/alunos" routerLinkActive="active">
+              <i class="fas fa-user-graduate"></i> Alunos
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" routerLink="/admin/turmas" routerLinkActive="active">
+              <i class="fas fa-chalkboard"></i> Turmas
+            </a>
+          </li>
+        </ul>
     </div>
 
     <!-- Rodapé da sidebar (opcional) -->


### PR DESCRIPTION
## Summary
- fix position of Cadastros section in sidebar
- show Alunos before Turmas

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a4bc04e88320bf31df836dfc1240