### PR TITLE
Add CRUD for usuarios and permissao

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/PermissaoGrupoController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/PermissaoGrupoController.java
@@ -1,0 +1,57 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sentinel.backend.entity.PermissaoGrupo;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.service.PermissaoGrupoService;
+
+@RestController
+@RequestMapping("/permissao")
+@CrossOrigin("*")
+public class PermissaoGrupoController {
+
+    @Autowired
+    private PermissaoGrupoService pgs;
+
+    @GetMapping("/findAll")
+    public Iterable<PermissaoGrupo> listar() {
+        return pgs.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return pgs.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody PermissaoGrupo permissaoGrupo) {
+        return pgs.cadastrarAlterar(permissaoGrupo, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody PermissaoGrupo permissaoGrupo) {
+        return pgs.cadastrarAlterar(permissaoGrupo, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<PermissaoGrupo> findById(@PathVariable long id) {
+        try {
+            PermissaoGrupo pg = pgs.findById(id);
+            return new ResponseEntity<>(pg, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
@@ -1,0 +1,57 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.entity.Usuario;
+import com.sentinel.backend.service.UsuarioService;
+
+@RestController
+@RequestMapping("/usuarios")
+@CrossOrigin("*")
+public class UsuariosController {
+
+    @Autowired
+    private UsuarioService us;
+
+    @GetMapping("/findAll")
+    public Iterable<Usuario> listar() {
+        return us.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return us.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody Usuario usuario) {
+        return us.cadastrarAlterar(usuario, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody Usuario usuario) {
+        return us.cadastrarAlterar(usuario, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<Usuario> findById(@PathVariable long id) {
+        try {
+            Usuario usuario = us.findById(id);
+            return new ResponseEntity<>(usuario, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/PermissaoGrupoRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/PermissaoGrupoRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.PermissaoGrupo;
+
+public interface PermissaoGrupoRepository extends JpaRepository<PermissaoGrupo, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/UsuarioRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/UsuarioRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.Usuario;
+
+public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/service/PermissaoGrupoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/PermissaoGrupoService.java
@@ -1,0 +1,52 @@
+package com.sentinel.backend.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.sentinel.backend.entity.PermissaoGrupo;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.repository.PermissaoGrupoRepository;
+
+@Service
+public class PermissaoGrupoService {
+
+    @Autowired
+    private PermissaoGrupoRepository pgr;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    public Iterable<PermissaoGrupo> listar() {
+        return pgr.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(PermissaoGrupo permissaoGrupo, String acao) {
+        if (permissaoGrupo.getNome() == null || permissaoGrupo.getNome().isEmpty()) {
+            rm.setMensagem("O nome do grupo de permissão é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            return new ResponseEntity<>(pgr.save(permissaoGrupo), HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(pgr.save(permissaoGrupo), HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!pgr.existsById(id)) {
+            rm.setMensagem("Grupo de permissão não encontrado!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+
+        pgr.deleteById(id);
+        rm.setMensagem("Grupo de permissão excluído com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public PermissaoGrupo findById(long id) {
+        return pgr.findById(id).get();
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
@@ -1,0 +1,61 @@
+package com.sentinel.backend.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.entity.Usuario;
+import com.sentinel.backend.repository.UsuarioRepository;
+
+@Service
+public class UsuarioService {
+
+    @Autowired
+    private UsuarioRepository ur;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    public Iterable<Usuario> listar() {
+        return ur.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(Usuario usuario, String acao) {
+        if (usuario.getNome() == null || usuario.getNome().isEmpty()) {
+            rm.setMensagem("O nome do Usuário é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        } else if (usuario.getEmail() == null || usuario.getEmail().isEmpty()) {
+            rm.setMensagem("O e-mail é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        } else if (usuario.getSenha() == null || usuario.getSenha().isEmpty()) {
+            rm.setMensagem("A senha é obrigatória!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        } else if (usuario.getPermissaoGrupo() == null) {
+            rm.setMensagem("O grupo de permissão é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            return new ResponseEntity<>(ur.save(usuario), HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(ur.save(usuario), HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!ur.existsById(id)) {
+            rm.setMensagem("Usuário não encontrado!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+
+        ur.deleteById(id);
+        rm.setMensagem("Usuário excluído com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public Usuario findById(long id) {
+        return ur.findById(id).get();
+    }
+}


### PR DESCRIPTION
## Summary
- implement repositories for `Usuario` and `PermissaoGrupo`
- implement services with validations
- add controllers with endpoints `/usuarios` and `/permissao`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6855a91f7e3c8320aff3b0f04d54d57c