### PR TITLE
Implement user and permission group CRUD

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,10 @@ import { TurmaslistComponent } from './components/turmas/turmaslist/turmaslist.c
 import { TurmasdetailsComponent } from './components/turmas/turmasdetails/turmasdetails.component';
 import { AlunoslistComponent } from './components/alunos/alunoslist/alunoslist.component';
 import { AlunosdetailsComponent } from './components/alunos/alunosdetails/alunosdetails.component';
+import { UsuarioslistComponent } from './components/usuarios/usuarioslist/usuarioslist.component';
+import { UsuariosdetailsComponent } from './components/usuarios/usuariosdetails/usuariosdetails.component';
+import { PermissaoGrupoListComponent } from './components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component';
+import { PermissaoGrupoDetailsComponent } from './components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component';
 
 
 export const routes: Routes = [
@@ -17,7 +21,13 @@ export const routes: Routes = [
     {path: "turmas/edit/:id", component: TurmasdetailsComponent},
     {path: "alunos", component: AlunoslistComponent},
     {path: "alunos/new", component: AlunosdetailsComponent},
-    {path: "alunos/edit/:id", component: AlunosdetailsComponent}
+    {path: "alunos/edit/:id", component: AlunosdetailsComponent},
+    {path: "usuarios", component: UsuarioslistComponent},
+    {path: "usuarios/new", component: UsuariosdetailsComponent},
+    {path: "usuarios/edit/:id", component: UsuariosdetailsComponent},
+    {path: "permissao", component: PermissaoGrupoListComponent},
+    {path: "permissao/new", component: PermissaoGrupoDetailsComponent},
+    {path: "permissao/edit/:id", component: PermissaoGrupoDetailsComponent}
 
   ]},
 

--- a/frontend/src/app/components/layout/sidebar/sidebar.component.html
+++ b/frontend/src/app/components/layout/sidebar/sidebar.component.html
@@ -34,6 +34,16 @@
               <i class="fas fa-chalkboard"></i> Turmas
             </a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" routerLink="/admin/usuarios" routerLinkActive="active">
+              <i class="fas fa-user"></i> Usuários
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" routerLink="/admin/permissao" routerLinkActive="active">
+              <i class="fas fa-users-cog"></i> Permissão Grupo
+            </a>
+          </li>
         </ul>
     </div>
 

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.css
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.css
@@ -1,0 +1,37 @@
+.card-title{
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-size: large;
+  color: #0a0a0a;
+
+}
+
+.form-control {
+  font-family: 'Roboto', sans-serif; /* Recomendo usar diretamente Roboto */
+  font-size: small; /* ~13px */
+  color: #0a0a0a;
+}
+
+
+.card {
+  margin-top: 50px;
+  display: inline-block; /* Faz o card se ajustar ao conteúdo */
+  width: 100%; /* Mantém a largura total */
+
+
+
+
+}
+
+.container {
+  background-color: #f9faef!important;
+
+}
+
+.card-body {
+  padding: 1rem; /* Mantém seu padding original */
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.6); /* eixo-x, eixo-y, desfoque, cor */
+  border: none;
+}
+

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.html
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.html
@@ -1,0 +1,30 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="card">
+      <div class="card-body">
+        <div class="col-lg-12">
+          <div class="card">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-4">
+                <h5 class="card-title mb-0">Cadastro de Permissão Grupo</h5>
+              </div>
+              <div class="row mb-3">
+                <div class="col-md-12 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="text" id="nome" class="form-control" [(ngModel)]="grupo.nome" />
+                    <label mdbLabel class="form-label" for="nome">Nome</label>
+                  </mdb-form-control>
+                </div>
+              </div>
+              <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-3">
+                <button type="button" class="btn btn-warning btn-rounded" mdbRipple (click)="save()">
+                  <i class="fas fa-save me-2"></i>Salvar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.ts
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.ts
@@ -1,0 +1,69 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import Swal from 'sweetalert2';
+import { PermissaoGrupo } from '../../../models/permissao-grupo';
+import { PermissaoGrupoService } from '../../../services/permissao-grupo.service';
+
+@Component({
+  selector: 'app-permissao-grupo-details',
+  standalone: true,
+  imports: [MdbFormsModule, FormsModule],
+  templateUrl: './permissao-grupo-details.component.html',
+  styleUrl: './permissao-grupo-details.component.css'
+})
+export class PermissaoGrupoDetailsComponent {
+
+  grupo: PermissaoGrupo = new PermissaoGrupo('');
+  router = inject(ActivatedRoute);
+  router2 = inject(Router);
+  pgService = inject(PermissaoGrupoService);
+
+  constructor() {
+    const id = this.router.snapshot.params['id'];
+    if (id > 0) {
+      this.findById(id);
+    }
+  }
+
+  findById(id: number) {
+    this.pgService.findById(id).subscribe({
+      next: ret => { this.grupo = ret; },
+      error: () => {
+        Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+      }
+    });
+  }
+
+  save() {
+    if (this.grupo.id) {
+      this.pgService.update(this.grupo).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Registro editado com sucesso!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/permissao']);
+        },
+        error: () => {
+          Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+        }
+      });
+    } else {
+      const grp = { ...this.grupo };
+      delete grp.id;
+      this.pgService.save(grp).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Registro cadastrado com sucesso!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/permissao']);
+        },
+        error: erro => {
+          console.error('Erro completo:', erro);
+          let mensagem = `Status: ${erro.status} - ${erro.statusText || 'Sem mensagem'}`;
+          if (erro.error && typeof erro.error === 'object' && erro.error.mensagem) {
+            mensagem = erro.error.mensagem;
+          }
+          Swal.fire({ title: 'Ocorreu um erro!', text: mensagem, icon: 'error', confirmButtonText: 'Ok' });
+        }
+      });
+    }
+  }
+}

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.css
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.css
@@ -1,0 +1,48 @@
+.card {
+  margin-top: 50px;
+  display: inline-block; /* Faz o card se ajustar ao conteúdo */
+  width: 100%; /* Mantém a largura total */
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.6); /* eixo-x, eixo-y, desfoque, cor */
+  border: none;
+
+
+
+}
+
+.card-title{
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-size: large;
+  color: #0a0a0a;
+
+}
+
+
+
+.container {
+  background-color: #f9faef!important;
+
+}
+
+.card-body {
+  padding: 1rem; /* Mantém seu padding original */
+  display: flex;
+  flex-direction: column;
+}
+
+.ag-theme-alpine {
+  --ag-grid-size: 6px;
+  --ag-list-item-height: 30px;
+
+  height: auto !important; /* Remove altura fixa */
+  min-height: 100px; /* Altura mínima */
+  flex-grow: 1; /* Cresce com o conteúdo */
+  padding-top: 50px;
+}
+
+/* Remove qualquer barra de rolagem */
+.ag-theme-alpine,
+.ag-theme-alpine .ag-root-wrapper,
+.card-body {
+  overflow: visible !important;
+
+}

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.html
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.html
@@ -1,0 +1,26 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="card">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-center mb-4">
+            <h5 class="card-title mb-0">Permissão Grupo</h5>
+            <button type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/permissao/new">
+              <i class="fas fa-plus me-1"></i> Novo Grupo
+            </button>
+          </div>
+          <div class="ag-theme-alpine">
+            <ag-grid-angular
+              style="width: 100%; height: 100%;"
+              [rowData]="rowData"
+              [columnDefs]="colDefs"
+              [defaultColDef]="defaultColDef"
+              [gridOptions]="gridOptions"
+              (gridReady)="onGridReady($event)">
+            </ag-grid-angular>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.ts
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.ts
@@ -1,0 +1,130 @@
+import { Component, inject } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { AgGridModule } from 'ag-grid-angular';
+import { ColDef, GridApi, GridOptions, GridReadyEvent } from 'ag-grid-community';
+import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
+import Swal from 'sweetalert2';
+import { PermissaoGrupo } from '../../../models/permissao-grupo';
+import { PermissaoGrupoService } from '../../../services/permissao-grupo.service';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+@Component({
+  selector: 'app-permissao-grupo-list',
+  standalone: true,
+  imports: [AgGridModule, RouterLink],
+  templateUrl: './permissao-grupo-list.component.html',
+  styleUrl: './permissao-grupo-list.component.css'
+})
+export class PermissaoGrupoListComponent {
+
+  private gridApi!: GridApi<PermissaoGrupo>;
+  public gridOptions: GridOptions<PermissaoGrupo> = {
+    pagination: true,
+    paginationPageSize: 20,
+    theme: 'legacy',
+    localeText: {
+      page: 'Página',
+      to: 'até',
+      of: 'de',
+      more: 'mais',
+      next: 'Próxima',
+      last: 'Última',
+      first: 'Primeira',
+      previous: 'Anterior',
+      loadingOoo: 'Carregando...',
+      noRowsToShow: 'Nenhum registro encontrado'
+    },
+    domLayout: 'autoHeight'
+  };
+
+  colDefs: ColDef<PermissaoGrupo>[] = [
+    { field: 'id', headerName: 'ID', filter: 'agNumberColumnFilter', floatingFilter: true },
+    { field: 'nome', headerName: 'Nome', filter: 'agTextColumnFilter', floatingFilter: true },
+    {
+      headerName: 'Ações',
+      cellRenderer: (params: any) => {
+        const pg = params.data;
+        return `
+          <button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${pg.id}">
+            <i class="fas fa-edit"></i>
+          </button>
+          <button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${pg.id}">
+            <i class="fas fa-trash-alt"></i>
+          </button>
+        `;
+      },
+      sortable: false,
+      filter: false,
+      cellClass: ['no-padding']
+    }
+  ];
+
+  defaultColDef: ColDef = {
+    sortable: true,
+    filter: true,
+    resizable: true,
+    flex: 1
+  };
+
+  rowData: PermissaoGrupo[] = [];
+  pgService = inject(PermissaoGrupoService);
+  router = inject(Router);
+
+  constructor() {
+    this.findAll();
+  }
+
+  ngAfterViewInit() {
+    document.addEventListener('click', (event) => {
+      const target = event.target as HTMLElement;
+      const button = target.closest('button[data-action]');
+      if (button) {
+        const action = button.getAttribute('data-action');
+        const id = button.getAttribute('data-id');
+        if (action === 'edit') {
+          this.router.navigate(['/admin/permissao/edit', id]);
+        } else if (action === 'delete') {
+          this.deleteById(Number(id));
+        }
+      }
+    });
+  }
+
+  findAll() {
+    this.pgService.findAll().subscribe({
+      next: lista => { this.rowData = lista; },
+      error: () => {
+        Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+      }
+    });
+  }
+
+  onGridReady(params: GridReadyEvent<PermissaoGrupo>) {
+    this.gridApi = params.api;
+    setTimeout(() => { params.api.sizeColumnsToFit(); }, 50);
+  }
+
+  deleteById(id: number) {
+    Swal.fire({
+      title: 'Confirma exclusão de registro?',
+      icon: 'warning',
+      showConfirmButton: true,
+      showDenyButton: true,
+      confirmButtonText: 'Sim',
+      denyButtonText: 'Não'
+    }).then((result) => {
+      if (result.isConfirmed) {
+        this.pgService.delete(id).subscribe({
+          next: () => {
+            Swal.fire({ title: 'Registro excluído!', icon: 'success', confirmButtonText: 'Ok' });
+            this.findAll();
+          },
+          error: () => {
+            Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+          }
+        });
+      }
+    });
+  }
+}

--- a/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.css
+++ b/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.css
@@ -1,0 +1,37 @@
+.card-title{
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-size: large;
+  color: #0a0a0a;
+
+}
+
+.form-control {
+  font-family: 'Roboto', sans-serif; /* Recomendo usar diretamente Roboto */
+  font-size: small; /* ~13px */
+  color: #0a0a0a;
+}
+
+
+.card {
+  margin-top: 50px;
+  display: inline-block; /* Faz o card se ajustar ao conteúdo */
+  width: 100%; /* Mantém a largura total */
+
+
+
+
+}
+
+.container {
+  background-color: #f9faef!important;
+
+}
+
+.card-body {
+  padding: 1rem; /* Mantém seu padding original */
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.6); /* eixo-x, eixo-y, desfoque, cor */
+  border: none;
+}
+

--- a/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.html
+++ b/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.html
@@ -1,0 +1,52 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="card">
+      <div class="card-body">
+        <div class="col-lg-12">
+          <div class="card">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-4">
+                <h5 class="card-title mb-0">Cadastro de Usuários</h5>
+              </div>
+              <div class="row mb-3">
+                <div class="col-md-6 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="text" id="nome" class="form-control" [(ngModel)]="usuario.nome" />
+                    <label mdbLabel class="form-label" for="nome">Nome</label>
+                  </mdb-form-control>
+                </div>
+                <div class="col-md-6 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="email" id="email" class="form-control" [(ngModel)]="usuario.email" />
+                    <label mdbLabel class="form-label" for="email">Email</label>
+                  </mdb-form-control>
+                </div>
+              </div>
+              <div class="row mb-4">
+                <div class="col-md-6 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="password" id="senha" class="form-control" [(ngModel)]="usuario.senha" />
+                    <label mdbLabel class="form-label" for="senha">Senha</label>
+                  </mdb-form-control>
+                </div>
+                <div class="col-md-6 mb-3">
+                  <mdb-form-control>
+                    <select mdbSelect class="form-select" [(ngModel)]="usuario.permissaoGrupo" [ngModelOptions]="{standalone: true}">
+                      <option *ngFor="let g of grupos" [ngValue]="g">{{ g.nome }}</option>
+                    </select>
+                    <label mdbLabel class="form-label" for="permissao">Permissão</label>
+                  </mdb-form-control>
+                </div>
+              </div>
+              <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-3">
+                <button type="button" class="btn btn-warning btn-rounded" mdbRipple (click)="save()">
+                  <i class="fas fa-save me-2"></i>Salvar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.ts
+++ b/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.ts
@@ -1,0 +1,83 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import Swal from 'sweetalert2';
+import { Usuario } from '../../../models/usuario';
+import { PermissaoGrupo } from '../../../models/permissao-grupo';
+import { UsuariosService } from '../../../services/usuarios.service';
+import { PermissaoGrupoService } from '../../../services/permissao-grupo.service';
+
+@Component({
+  selector: 'app-usuariosdetails',
+  standalone: true,
+  imports: [MdbFormsModule, FormsModule],
+  templateUrl: './usuariosdetails.component.html',
+  styleUrl: './usuariosdetails.component.css'
+})
+export class UsuariosdetailsComponent {
+
+  usuario: Usuario = new Usuario('', '', '', null);
+  grupos: PermissaoGrupo[] = [];
+  router = inject(ActivatedRoute);
+  router2 = inject(Router);
+  usuariosService = inject(UsuariosService);
+  grupoService = inject(PermissaoGrupoService);
+
+  constructor() {
+    const id = this.router.snapshot.params['id'];
+    this.loadGrupos();
+    if (id > 0) {
+      this.findById(id);
+    }
+  }
+
+  loadGrupos() {
+    this.grupoService.findAll().subscribe({
+      next: lista => { this.grupos = lista; },
+      error: () => {
+        Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+      }
+    });
+  }
+
+  findById(id: number) {
+    this.usuariosService.findById(id).subscribe({
+      next: retorno => { this.usuario = retorno; },
+      error: () => {
+        Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+      }
+    });
+  }
+
+  save() {
+    if (this.usuario.id) {
+      this.usuariosService.update(this.usuario).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Usuário editado com sucesso!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/usuarios']);
+        },
+        error: () => {
+          Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+        }
+      });
+    } else {
+      const usuarioParaSalvar = { ...this.usuario };
+      delete usuarioParaSalvar.id;
+      this.usuariosService.save(usuarioParaSalvar).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Usuário cadastrado com sucesso!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/usuarios']);
+        },
+        error: erro => {
+          console.error('Erro completo:', erro);
+          let mensagem = `Status: ${erro.status} - ${erro.statusText || 'Sem mensagem'}`;
+          if (erro.error && typeof erro.error === 'object' && erro.error.mensagem) {
+            mensagem = erro.error.mensagem;
+          }
+          Swal.fire({ title: 'Ocorreu um erro!', text: mensagem, icon: 'error', confirmButtonText: 'Ok' });
+        }
+      });
+    }
+  }
+}

--- a/frontend/src/app/components/usuarios/usuarioslist/usuarioslist.component.css
+++ b/frontend/src/app/components/usuarios/usuarioslist/usuarioslist.component.css
@@ -1,0 +1,48 @@
+.card {
+  margin-top: 50px;
+  display: inline-block; /* Faz o card se ajustar ao conteúdo */
+  width: 100%; /* Mantém a largura total */
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.6); /* eixo-x, eixo-y, desfoque, cor */
+  border: none;
+
+
+
+}
+
+.card-title{
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-size: large;
+  color: #0a0a0a;
+
+}
+
+
+
+.container {
+  background-color: #f9faef!important;
+
+}
+
+.card-body {
+  padding: 1rem; /* Mantém seu padding original */
+  display: flex;
+  flex-direction: column;
+}
+
+.ag-theme-alpine {
+  --ag-grid-size: 6px;
+  --ag-list-item-height: 30px;
+
+  height: auto !important; /* Remove altura fixa */
+  min-height: 100px; /* Altura mínima */
+  flex-grow: 1; /* Cresce com o conteúdo */
+  padding-top: 50px;
+}
+
+/* Remove qualquer barra de rolagem */
+.ag-theme-alpine,
+.ag-theme-alpine .ag-root-wrapper,
+.card-body {
+  overflow: visible !important;
+
+}

--- a/frontend/src/app/components/usuarios/usuarioslist/usuarioslist.component.html
+++ b/frontend/src/app/components/usuarios/usuarioslist/usuarioslist.component.html
@@ -1,0 +1,26 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="card">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-center mb-4">
+            <h5 class="card-title mb-0">Usuários</h5>
+            <button type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/usuarios/new">
+              <i class="fas fa-plus me-1"></i> Novo Usuário
+            </button>
+          </div>
+          <div class="ag-theme-alpine">
+            <ag-grid-angular
+              style="width: 100%; height: 100%;"
+              [rowData]="rowData"
+              [columnDefs]="colDefs"
+              [defaultColDef]="defaultColDef"
+              [gridOptions]="gridOptions"
+              (gridReady)="onGridReady($event)">
+            </ag-grid-angular>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/models/permissao-grupo.ts
+++ b/frontend/src/app/models/permissao-grupo.ts
@@ -1,0 +1,9 @@
+export class PermissaoGrupo {
+  id?: number;
+  nome: string;
+
+  constructor(nome: string, id?: number) {
+    this.id = id;
+    this.nome = nome;
+  }
+}

--- a/frontend/src/app/models/usuario.ts
+++ b/frontend/src/app/models/usuario.ts
@@ -1,0 +1,23 @@
+import { PermissaoGrupo } from './permissao-grupo';
+
+export class Usuario {
+  id?: number;
+  nome: string;
+  email: string;
+  senha: string;
+  permissaoGrupo: PermissaoGrupo | null;
+
+  constructor(
+    nome: string,
+    email: string,
+    senha: string,
+    permissaoGrupo: PermissaoGrupo | null,
+    id?: number
+  ) {
+    this.id = id;
+    this.nome = nome;
+    this.email = email;
+    this.senha = senha;
+    this.permissaoGrupo = permissaoGrupo;
+  }
+}

--- a/frontend/src/app/services/permissao-grupo.service.ts
+++ b/frontend/src/app/services/permissao-grupo.service.ts
@@ -1,0 +1,33 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { PermissaoGrupo } from '../models/permissao-grupo';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PermissaoGrupoService {
+
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/permissao';
+
+  findAll(): Observable<PermissaoGrupo[]> {
+    return this.http.get<PermissaoGrupo[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(pg: PermissaoGrupo): Observable<string> {
+    return this.http.post<string>(this.API + '/save', pg, { responseType: 'text' as 'json' });
+  }
+
+  update(pg: PermissaoGrupo): Observable<string> {
+    return this.http.put<string>(this.API + '/update', pg, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<PermissaoGrupo> {
+    return this.http.get<PermissaoGrupo>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/usuarios.service.ts
+++ b/frontend/src/app/services/usuarios.service.ts
@@ -1,0 +1,33 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Usuario } from '../models/usuario';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UsuariosService {
+
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/usuarios';
+
+  findAll(): Observable<Usuario[]> {
+    return this.http.get<Usuario[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(usuario: Usuario): Observable<string> {
+    return this.http.post<string>(this.API + '/save', usuario, { responseType: 'text' as 'json' });
+  }
+
+  update(usuario: Usuario): Observable<string> {
+    return this.http.put<string>(this.API + '/update', usuario, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<Usuario> {
+    return this.http.get<Usuario>(this.API + '/findById/' + id);
+  }
+}


### PR DESCRIPTION
## Summary
- add models for `Usuario` and `PermissaoGrupo`
- create services to call `/usuarios` and `/permissao`
- implement list/detail components for users and permission groups
- update sidebar navigation and routes

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ab67e4c88320886e80a92faf48bd