### PR TITLE
Fix permission select default on user edit

### DIFF
--- a/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.html
+++ b/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.html
@@ -31,7 +31,7 @@
                 </div>
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <select mdbInput class="form-select" [(ngModel)]="usuario.permissaoGrupo" [ngModelOptions]="{standalone: true}">
+                    <select mdbInput class="form-select" [(ngModel)]="usuario.permissaoGrupo" [compareWith]="compareGrupoFn" [ngModelOptions]="{standalone: true}">
                       <option *ngFor="let g of grupos" [ngValue]="g">{{ g.nome }}</option>
                     </select>
                     <label mdbLabel class="form-label" for="permissao">Permissão</label>

--- a/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.ts
+++ b/frontend/src/app/components/usuarios/usuariosdetails/usuariosdetails.component.ts
@@ -26,6 +26,14 @@ export class UsuariosdetailsComponent implements OnInit {
   usuariosService = inject(UsuariosService);
   grupoService = inject(PermissaoGrupoService);
 
+  /**
+   * Função de comparação utilizada pelo select de grupos de permissão
+   * para que o valor seja selecionado corretamente ao editar um usuário.
+   */
+  compareGrupoFn(g1: PermissaoGrupo | null, g2: PermissaoGrupo | null): boolean {
+    return g1 !== null && g2 !== null ? g1.id === g2.id : g1 === g2;
+  }
+
   constructor() {
     const id = this.router.snapshot.params['id'];
     if (id > 0) {


### PR DESCRIPTION
## Summary
- add compare function for permission groups
- bind compare function in user edit template

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d02946688320b9b24558646adbd6