### PR TITLE
Add logging for findById endpoints

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/AlunosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/AlunosController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.sentinel.backend.entity.Aluno;
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.service.AlunoService;
@@ -20,6 +22,7 @@ import com.sentinel.backend.service.AlunoService;
 @RestController
 @RequestMapping("/alunos")
 @CrossOrigin("*")
+@Slf4j
 public class AlunosController {
 
     @Autowired
@@ -47,10 +50,13 @@ public class AlunosController {
 
     @GetMapping("/findById/{id}")
     public ResponseEntity<Aluno> findById(@PathVariable long id) {
+        log.info("Finding aluno with id {}", id);
         try {
             Aluno aluno = as.findById(id);
+            log.info("Aluno {} found", id);
             return new ResponseEntity<>(aluno, HttpStatus.OK);
         } catch (Exception e) {
+            log.error("Error retrieving aluno {}", id, e);
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
     }

--- a/backend/src/main/java/com/sentinel/backend/controller/PermissaoGrupoController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/PermissaoGrupoController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.sentinel.backend.entity.PermissaoGrupo;
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.service.PermissaoGrupoService;
@@ -20,6 +22,7 @@ import com.sentinel.backend.service.PermissaoGrupoService;
 @RestController
 @RequestMapping("/permissao")
 @CrossOrigin("*")
+@Slf4j
 public class PermissaoGrupoController {
 
     @Autowired
@@ -47,10 +50,13 @@ public class PermissaoGrupoController {
 
     @GetMapping("/findById/{id}")
     public ResponseEntity<PermissaoGrupo> findById(@PathVariable long id) {
+        log.info("Finding permissaoGrupo with id {}", id);
         try {
             PermissaoGrupo pg = pgs.findById(id);
+            log.info("PermissaoGrupo {} found", id);
             return new ResponseEntity<>(pg, HttpStatus.OK);
         } catch (Exception e) {
+            log.error("Error retrieving permissaoGrupo {}", id, e);
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
     }

--- a/backend/src/main/java/com/sentinel/backend/controller/TurmasController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/TurmasController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.entity.Turma;
 
@@ -21,6 +23,7 @@ import com.sentinel.backend.service.TurmasService;
 @RestController
 @RequestMapping("/turmas")
 @CrossOrigin("*")
+@Slf4j
 public class TurmasController {
 
     @Autowired
@@ -50,12 +53,15 @@ public class TurmasController {
     // Listar por id
     @GetMapping("/findById/{id}")
     public ResponseEntity<Turma> findById(@PathVariable long id) {
+        log.info("Finding turma with id {}", id);
         try {
 
             Turma turma = this.ts.findById(id);
+            log.info("Turma {} found", id);
             return new ResponseEntity<>(turma, HttpStatus.OK);
 
         } catch (Exception e) {
+            log.error("Error retrieving turma {}", id, e);
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
 

--- a/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.entity.Usuario;
 import com.sentinel.backend.service.UsuarioService;
@@ -20,6 +22,7 @@ import com.sentinel.backend.service.UsuarioService;
 @RestController
 @RequestMapping("/usuarios")
 @CrossOrigin("*")
+@Slf4j
 public class UsuariosController {
 
     @Autowired
@@ -47,10 +50,13 @@ public class UsuariosController {
 
     @GetMapping("/findById/{id}")
     public ResponseEntity<Usuario> findById(@PathVariable long id) {
+        log.info("Finding usuario with id {}", id);
         try {
             Usuario usuario = us.findById(id);
+            log.info("Usuario {} found", id);
             return new ResponseEntity<>(usuario, HttpStatus.OK);
         } catch (Exception e) {
+            log.error("Error retrieving usuario {}", id, e);
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         }
     }

--- a/backend/src/main/java/com/sentinel/backend/service/AlunoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/AlunoService.java
@@ -5,11 +5,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.sentinel.backend.entity.Aluno;
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.repository.AlunoRepository;
 
 @Service
+@Slf4j
 public class AlunoService {
 
     @Autowired
@@ -47,6 +50,9 @@ public class AlunoService {
     }
 
     public Aluno findById(long id) {
-        return ar.findById(id).get();
+        log.debug("Fetching aluno id {}", id);
+        Aluno aluno = ar.findById(id).get();
+        log.debug("Fetched aluno id {}", id);
+        return aluno;
     }
 }

--- a/backend/src/main/java/com/sentinel/backend/service/PermissaoGrupoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/PermissaoGrupoService.java
@@ -5,11 +5,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.sentinel.backend.entity.PermissaoGrupo;
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.repository.PermissaoGrupoRepository;
 
 @Service
+@Slf4j
 public class PermissaoGrupoService {
 
     @Autowired
@@ -47,6 +50,9 @@ public class PermissaoGrupoService {
     }
 
     public PermissaoGrupo findById(long id) {
-        return pgr.findById(id).get();
+        log.debug("Fetching permissaoGrupo id {}", id);
+        PermissaoGrupo pg = pgr.findById(id).get();
+        log.debug("Fetched permissaoGrupo id {}", id);
+        return pg;
     }
 }

--- a/backend/src/main/java/com/sentinel/backend/service/TurmasService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/TurmasService.java
@@ -5,12 +5,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.entity.Turma;
 
 import com.sentinel.backend.repository.TurmasRepository;
 
 @Service
+@Slf4j
 public class TurmasService {
 
     @Autowired
@@ -63,7 +66,9 @@ public class TurmasService {
     }
 
     public Turma findById(long id) {
+        log.debug("Fetching turma id {}", id);
         Turma turma = this.tr.findById(id).get();
+        log.debug("Fetched turma id {}", id);
         return turma;
 
     }

--- a/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
@@ -5,11 +5,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.sentinel.backend.entity.RespostaModelo;
 import com.sentinel.backend.entity.Usuario;
 import com.sentinel.backend.repository.UsuarioRepository;
 
 @Service
+@Slf4j
 public class UsuarioService {
 
     @Autowired
@@ -56,6 +59,9 @@ public class UsuarioService {
     }
 
     public Usuario findById(long id) {
-        return ur.findById(id).get();
+        log.debug("Fetching usuario id {}", id);
+        Usuario usuario = ur.findById(id).get();
+        log.debug("Fetched usuario id {}", id);
+        return usuario;
     }
 }


### PR DESCRIPTION
## Summary
- add `Slf4j` logging to controllers and services
- log when entities are fetched and when errors occur

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593cc79fec8320883692bcbfe2ba9f