### PR TITLE
fix: return 404 when record not found

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/AlunosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/AlunosController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.NoSuchElementException;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.sentinel.backend.entity.Aluno;
@@ -55,6 +57,9 @@ public class AlunosController {
             Aluno aluno = as.findById(id);
             log.info("Aluno {} found", id);
             return new ResponseEntity<>(aluno, HttpStatus.OK);
+        } catch (NoSuchElementException e) {
+            log.error("Aluno {} not found", id, e);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving aluno {}", id, e);
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/sentinel/backend/controller/PermissaoGrupoController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/PermissaoGrupoController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.NoSuchElementException;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.sentinel.backend.entity.PermissaoGrupo;
@@ -55,6 +57,9 @@ public class PermissaoGrupoController {
             PermissaoGrupo pg = pgs.findById(id);
             log.info("PermissaoGrupo {} found", id);
             return new ResponseEntity<>(pg, HttpStatus.OK);
+        } catch (NoSuchElementException e) {
+            log.error("PermissaoGrupo {} not found", id, e);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving permissaoGrupo {}", id, e);
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/sentinel/backend/controller/TurmasController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/TurmasController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.NoSuchElementException;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.sentinel.backend.entity.RespostaModelo;
@@ -60,6 +62,9 @@ public class TurmasController {
             log.info("Turma {} found", id);
             return new ResponseEntity<>(turma, HttpStatus.OK);
 
+        } catch (NoSuchElementException e) {
+            log.error("Turma {} not found", id, e);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving turma {}", id, e);
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.NoSuchElementException;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.sentinel.backend.entity.RespostaModelo;
@@ -55,6 +57,9 @@ public class UsuariosController {
             Usuario usuario = us.findById(id);
             log.info("Usuario {} found", id);
             return new ResponseEntity<>(usuario, HttpStatus.OK);
+        } catch (NoSuchElementException e) {
+            log.error("Usuario {} not found", id, e);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving usuario {}", id, e);
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/sentinel/backend/service/AlunoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/AlunoService.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.sentinel.backend.entity.Aluno;
@@ -51,7 +53,8 @@ public class AlunoService {
 
     public Aluno findById(long id) {
         log.debug("Fetching aluno id {}", id);
-        Aluno aluno = ar.findById(id).get();
+        Aluno aluno = ar.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("Aluno não encontrado"));
         log.debug("Fetched aluno id {}", id);
         return aluno;
     }

--- a/backend/src/main/java/com/sentinel/backend/service/PermissaoGrupoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/PermissaoGrupoService.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.sentinel.backend.entity.PermissaoGrupo;
@@ -51,7 +53,8 @@ public class PermissaoGrupoService {
 
     public PermissaoGrupo findById(long id) {
         log.debug("Fetching permissaoGrupo id {}", id);
-        PermissaoGrupo pg = pgr.findById(id).get();
+        PermissaoGrupo pg = pgr.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("Grupo de permissão não encontrado"));
         log.debug("Fetched permissaoGrupo id {}", id);
         return pg;
     }

--- a/backend/src/main/java/com/sentinel/backend/service/TurmasService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/TurmasService.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.sentinel.backend.entity.RespostaModelo;
@@ -67,7 +69,8 @@ public class TurmasService {
 
     public Turma findById(long id) {
         log.debug("Fetching turma id {}", id);
-        Turma turma = this.tr.findById(id).get();
+        Turma turma = this.tr.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("Turma não encontrada"));
         log.debug("Fetched turma id {}", id);
         return turma;
 

--- a/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 import lombok.extern.slf4j.Slf4j;
 
 import com.sentinel.backend.entity.RespostaModelo;
@@ -60,7 +62,8 @@ public class UsuarioService {
 
     public Usuario findById(long id) {
         log.debug("Fetching usuario id {}", id);
-        Usuario usuario = ur.findById(id).get();
+        Usuario usuario = ur.findById(id)
+            .orElseThrow(() -> new NoSuchElementException("Usuário não encontrado"));
         log.debug("Fetched usuario id {}", id);
         return usuario;
     }


### PR DESCRIPTION
## Summary
- handle `Optional` properly in service layer
- return 404 status for missing records in controllers

## Testing
- `./mvnw -q test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6859489750588320b2c18f73dd90d8f9