### PR TITLE
Improve user lookup error handling

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,11 +54,12 @@ public class UsuariosController {
     public ResponseEntity<Usuario> findById(@PathVariable long id) {
         log.info("Finding usuario with id {}", id);
         try {
-            Usuario usuario = us.findById(id);
-            log.info("Usuario {} found", id);
-            return new ResponseEntity<>(usuario, HttpStatus.OK);
-        } catch (NoSuchElementException e) {
-            log.error("Usuario {} not found", id, e);
+            Optional<Usuario> optUsuario = us.findById(id);
+            if (optUsuario.isPresent()) {
+                log.info("Usuario {} found", id);
+                return new ResponseEntity<>(optUsuario.get(), HttpStatus.OK);
+            }
+            log.warn("Usuario {} not found", id);
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving usuario {}", id, e);

--- a/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,11 +60,10 @@ public class UsuarioService {
         return new ResponseEntity<>(rm, HttpStatus.OK);
     }
 
-    public Usuario findById(long id) {
+    public Optional<Usuario> findById(long id) {
         log.debug("Fetching usuario id {}", id);
-        Usuario usuario = ur.findById(id)
-            .orElseThrow(() -> new NoSuchElementException("Usuário não encontrado"));
-        log.debug("Fetched usuario id {}", id);
+        Optional<Usuario> usuario = ur.findById(id);
+        usuario.ifPresent(u -> log.debug("Fetched usuario id {}", id));
         return usuario;
     }
 }


### PR DESCRIPTION
## Summary
- update `UsuarioService.findById` to return `Optional` instead of throwing
- adjust `UsuariosController` to handle missing users gracefully

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68594a9cf3b0832091224e21ed09da11