### PR TITLE
Improve entity retrieval across services

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/AlunosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/AlunosController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,11 +54,12 @@ public class AlunosController {
     public ResponseEntity<Aluno> findById(@PathVariable long id) {
         log.info("Finding aluno with id {}", id);
         try {
-            Aluno aluno = as.findById(id);
-            log.info("Aluno {} found", id);
-            return new ResponseEntity<>(aluno, HttpStatus.OK);
-        } catch (NoSuchElementException e) {
-            log.error("Aluno {} not found", id, e);
+            Optional<Aluno> optAluno = as.findById(id);
+            if (optAluno.isPresent()) {
+                log.info("Aluno {} found", id);
+                return new ResponseEntity<>(optAluno.get(), HttpStatus.OK);
+            }
+            log.warn("Aluno {} not found", id);
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving aluno {}", id, e);

--- a/backend/src/main/java/com/sentinel/backend/controller/PermissaoGrupoController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/PermissaoGrupoController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,11 +54,12 @@ public class PermissaoGrupoController {
     public ResponseEntity<PermissaoGrupo> findById(@PathVariable long id) {
         log.info("Finding permissaoGrupo with id {}", id);
         try {
-            PermissaoGrupo pg = pgs.findById(id);
-            log.info("PermissaoGrupo {} found", id);
-            return new ResponseEntity<>(pg, HttpStatus.OK);
-        } catch (NoSuchElementException e) {
-            log.error("PermissaoGrupo {} not found", id, e);
+            Optional<PermissaoGrupo> pg = pgs.findById(id);
+            if (pg.isPresent()) {
+                log.info("PermissaoGrupo {} found", id);
+                return new ResponseEntity<>(pg.get(), HttpStatus.OK);
+            }
+            log.warn("PermissaoGrupo {} not found", id);
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving permissaoGrupo {}", id, e);

--- a/backend/src/main/java/com/sentinel/backend/controller/TurmasController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/TurmasController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -58,12 +58,13 @@ public class TurmasController {
         log.info("Finding turma with id {}", id);
         try {
 
-            Turma turma = this.ts.findById(id);
-            log.info("Turma {} found", id);
-            return new ResponseEntity<>(turma, HttpStatus.OK);
+            Optional<Turma> turma = this.ts.findById(id);
+            if (turma.isPresent()) {
+                log.info("Turma {} found", id);
+                return new ResponseEntity<>(turma.get(), HttpStatus.OK);
+            }
 
-        } catch (NoSuchElementException e) {
-            log.error("Turma {} not found", id, e);
+            log.warn("Turma {} not found", id);
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving turma {}", id, e);

--- a/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/UsuariosController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,11 +54,12 @@ public class UsuariosController {
     public ResponseEntity<Usuario> findById(@PathVariable long id) {
         log.info("Finding usuario with id {}", id);
         try {
-            Usuario usuario = us.findById(id);
-            log.info("Usuario {} found", id);
-            return new ResponseEntity<>(usuario, HttpStatus.OK);
-        } catch (NoSuchElementException e) {
-            log.error("Usuario {} not found", id, e);
+            Optional<Usuario> optUsuario = us.findById(id);
+            if (optUsuario.isPresent()) {
+                log.info("Usuario {} found", id);
+                return new ResponseEntity<>(optUsuario.get(), HttpStatus.OK);
+            }
+            log.warn("Usuario {} not found", id);
             return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             log.error("Error retrieving usuario {}", id, e);

--- a/backend/src/main/java/com/sentinel/backend/service/AlunoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/AlunoService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,11 +51,10 @@ public class AlunoService {
         return new ResponseEntity<>(rm, HttpStatus.OK);
     }
 
-    public Aluno findById(long id) {
+    public Optional<Aluno> findById(long id) {
         log.debug("Fetching aluno id {}", id);
-        Aluno aluno = ar.findById(id)
-            .orElseThrow(() -> new NoSuchElementException("Aluno não encontrado"));
-        log.debug("Fetched aluno id {}", id);
+        Optional<Aluno> aluno = ar.findById(id);
+        aluno.ifPresent(a -> log.debug("Fetched aluno id {}", id));
         return aluno;
     }
 }

--- a/backend/src/main/java/com/sentinel/backend/service/PermissaoGrupoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/PermissaoGrupoService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,11 +51,10 @@ public class PermissaoGrupoService {
         return new ResponseEntity<>(rm, HttpStatus.OK);
     }
 
-    public PermissaoGrupo findById(long id) {
+    public Optional<PermissaoGrupo> findById(long id) {
         log.debug("Fetching permissaoGrupo id {}", id);
-        PermissaoGrupo pg = pgr.findById(id)
-            .orElseThrow(() -> new NoSuchElementException("Grupo de permissão não encontrado"));
-        log.debug("Fetched permissaoGrupo id {}", id);
+        Optional<PermissaoGrupo> pg = pgr.findById(id);
+        pg.ifPresent(p -> log.debug("Fetched permissaoGrupo id {}", id));
         return pg;
     }
 }

--- a/backend/src/main/java/com/sentinel/backend/service/TurmasService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/TurmasService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -67,11 +67,10 @@ public class TurmasService {
         return new ResponseEntity<>(rm, HttpStatus.OK);
     }
 
-    public Turma findById(long id) {
+    public Optional<Turma> findById(long id) {
         log.debug("Fetching turma id {}", id);
-        Turma turma = this.tr.findById(id)
-            .orElseThrow(() -> new NoSuchElementException("Turma não encontrada"));
-        log.debug("Fetched turma id {}", id);
+        Optional<Turma> turma = this.tr.findById(id);
+        turma.ifPresent(t -> log.debug("Fetched turma id {}", id));
         return turma;
 
     }

--- a/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/UsuarioService.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,11 +60,10 @@ public class UsuarioService {
         return new ResponseEntity<>(rm, HttpStatus.OK);
     }
 
-    public Usuario findById(long id) {
+    public Optional<Usuario> findById(long id) {
         log.debug("Fetching usuario id {}", id);
-        Usuario usuario = ur.findById(id)
-            .orElseThrow(() -> new NoSuchElementException("Usuário não encontrado"));
-        log.debug("Fetched usuario id {}", id);
+        Optional<Usuario> usuario = ur.findById(id);
+        usuario.ifPresent(u -> log.debug("Fetched usuario id {}", id));
         return usuario;
     }
 }


### PR DESCRIPTION
## Summary
- return `Optional` for `Aluno`, `Turma`, and `PermissaoGrupo` services
- update controllers to check for missing records

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68594a9cf3b0832091224e21ed09da11