### PR TITLE
Implement permissao pagina

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/PermissaoPaginaController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/PermissaoPaginaController.java
@@ -1,0 +1,69 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import com.sentinel.backend.entity.PermissaoPagina;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.service.PermissaoPaginaService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/paginas")
+@CrossOrigin("*")
+@Slf4j
+public class PermissaoPaginaController {
+
+    @Autowired
+    private PermissaoPaginaService pps;
+
+    @GetMapping("/findAll")
+    public Iterable<PermissaoPagina> listar() {
+        return pps.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return pps.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody PermissaoPagina permissaoPagina) {
+        return pps.cadastrarAlterar(permissaoPagina, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody PermissaoPagina permissaoPagina) {
+        return pps.cadastrarAlterar(permissaoPagina, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<PermissaoPagina> findById(@PathVariable long id) {
+        log.info("Finding permissaoPagina with id {}", id);
+        try {
+            Optional<PermissaoPagina> pg = pps.findById(id);
+            if (pg.isPresent()) {
+                log.info("PermissaoPagina {} found", id);
+                return new ResponseEntity<>(pg.get(), HttpStatus.OK);
+            }
+            log.warn("PermissaoPagina {} not found", id);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            log.error("Error retrieving permissaoPagina {}", id, e);
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/PermissaoPaginaRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/PermissaoPaginaRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.PermissaoPagina;
+
+public interface PermissaoPaginaRepository extends JpaRepository<PermissaoPagina, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/service/PermissaoPaginaService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/PermissaoPaginaService.java
@@ -1,0 +1,60 @@
+package com.sentinel.backend.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import com.sentinel.backend.entity.PermissaoPagina;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.repository.PermissaoPaginaRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PermissaoPaginaService {
+
+    @Autowired
+    private PermissaoPaginaRepository ppr;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    public Iterable<PermissaoPagina> listar() {
+        return ppr.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(PermissaoPagina permissaoPagina, String acao) {
+        if (permissaoPagina.getNome() == null || permissaoPagina.getNome().isEmpty()) {
+            rm.setMensagem("O nome da permissão de página é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            return new ResponseEntity<>(ppr.save(permissaoPagina), HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(ppr.save(permissaoPagina), HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!ppr.existsById(id)) {
+            rm.setMensagem("Permissão de página não encontrada!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+
+        ppr.deleteById(id);
+        rm.setMensagem("Permissão de página excluída com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public Optional<PermissaoPagina> findById(long id) {
+        log.debug("Fetching permissaoPagina id {}", id);
+        Optional<PermissaoPagina> pp = ppr.findById(id);
+        pp.ifPresent(p -> log.debug("Fetched permissaoPagina id {}", id));
+        return pp;
+    }
+}

--- a/docs/permissoes_pagina.sql
+++ b/docs/permissoes_pagina.sql
@@ -1,0 +1,18 @@
+-- Script para inserção das permissões de página básicas
+INSERT INTO permissoes_pagina (nome, rota, metodo_http) VALUES
+('Cadastro de Usuários (visualizar)', '/usuarios', 'GET'),
+('Cadastro de Usuários (incluir)', '/usuarios', 'POST'),
+('Cadastro de Usuários (alterar)', '/usuarios', 'PUT'),
+('Cadastro de Usuários (excluir)', '/usuarios', 'DELETE'),
+('Cadastro de Turmas (visualizar)', '/turmas', 'GET'),
+('Cadastro de Turmas (incluir)', '/turmas', 'POST'),
+('Cadastro de Turmas (alterar)', '/turmas', 'PUT'),
+('Cadastro de Turmas (excluir)', '/turmas', 'DELETE'),
+('Cadastro de Alunos (visualizar)', '/alunos', 'GET'),
+('Cadastro de Alunos (incluir)', '/alunos', 'POST'),
+('Cadastro de Alunos (alterar)', '/alunos', 'PUT'),
+('Cadastro de Alunos (excluir)', '/alunos', 'DELETE'),
+('Permissão de Grupo (visualizar)', '/permissao', 'GET'),
+('Permissão de Grupo (incluir)', '/permissao', 'POST'),
+('Permissão de Grupo (alterar)', '/permissao', 'PUT'),
+('Permissão de Grupo (excluir)', '/permissao', 'DELETE');

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.html
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.html
@@ -16,6 +16,15 @@
                   </mdb-form-control>
                 </div>
               </div>
+              <div class="row mb-3">
+                <div class="col-md-12">
+                  <label class="form-label mb-2">Permissões de Página</label>
+                  <div class="form-check" *ngFor="let p of permissoesPagina">
+                    <input class="form-check-input" type="checkbox" [id]="'pag'+p.id" [checked]="grupo.permissoes?.some(pg => pg.id === p.id)" (change)="togglePermissao(p, $event.target.checked)" />
+                    <label class="form-check-label" [for]="'pag'+p.id">{{ p.nome }}</label>
+                  </div>
+                </div>
+              </div>
               <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-3">
                 <button type="button" class="btn btn-warning btn-rounded" mdbRipple (click)="save()">
                   <i class="fas fa-save me-2"></i>Salvar

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.ts
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component.ts
@@ -1,11 +1,13 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
 import { MdbRippleModule } from 'mdb-angular-ui-kit/ripple';
 import { ActivatedRoute, Router } from '@angular/router';
 import Swal from 'sweetalert2';
 import { PermissaoGrupo } from '../../../models/permissao-grupo';
+import { PermissaoPagina } from '../../../models/permissao-pagina';
 import { PermissaoGrupoService } from '../../../services/permissao-grupo.service';
+import { PermissaoPaginaService } from '../../../services/permissao-pagina.service';
 
 @Component({
   selector: 'app-permissao-grupo-details',
@@ -14,17 +16,45 @@ import { PermissaoGrupoService } from '../../../services/permissao-grupo.service
   templateUrl: './permissao-grupo-details.component.html',
   styleUrl: './permissao-grupo-details.component.css'
 })
-export class PermissaoGrupoDetailsComponent {
+export class PermissaoGrupoDetailsComponent implements OnInit {
 
   grupo: PermissaoGrupo = new PermissaoGrupo('');
+  permissoesPagina: PermissaoPagina[] = [];
   router = inject(ActivatedRoute);
   router2 = inject(Router);
   pgService = inject(PermissaoGrupoService);
+  ppService = inject(PermissaoPaginaService);
 
   constructor() {
     const id = this.router.snapshot.params['id'];
     if (id > 0) {
       this.findById(id);
+    }
+  }
+
+  ngOnInit(): void {
+    this.loadPermissoesPagina();
+  }
+
+  loadPermissoesPagina() {
+    this.ppService.findAll().subscribe({
+      next: lista => { this.permissoesPagina = lista; },
+      error: () => {
+        Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+      }
+    });
+  }
+
+  togglePermissao(perm: PermissaoPagina, checked: boolean) {
+    if (checked) {
+      if (!this.grupo.permissoes) {
+        this.grupo.permissoes = [];
+      }
+      if (!this.grupo.permissoes.find(p => p.id === perm.id)) {
+        this.grupo.permissoes.push(perm);
+      }
+    } else {
+      this.grupo.permissoes = this.grupo.permissoes.filter(p => p.id !== perm.id);
     }
   }
 

--- a/frontend/src/app/models/permissao-grupo.ts
+++ b/frontend/src/app/models/permissao-grupo.ts
@@ -1,9 +1,13 @@
+import { PermissaoPagina } from './permissao-pagina';
+
 export class PermissaoGrupo {
   id?: number;
   nome: string;
+  permissoes: PermissaoPagina[];
 
-  constructor(nome: string, id?: number) {
+  constructor(nome: string, id?: number, permissoes: PermissaoPagina[] = []) {
     this.id = id;
     this.nome = nome;
+    this.permissoes = permissoes;
   }
 }

--- a/frontend/src/app/models/permissao-pagina.ts
+++ b/frontend/src/app/models/permissao-pagina.ts
@@ -1,0 +1,13 @@
+export class PermissaoPagina {
+  id?: number;
+  nome: string;
+  rota: string;
+  metodoHttp: string;
+
+  constructor(nome: string, rota: string, metodoHttp: string, id?: number) {
+    this.id = id;
+    this.nome = nome;
+    this.rota = rota;
+    this.metodoHttp = metodoHttp;
+  }
+}

--- a/frontend/src/app/services/permissao-pagina.service.ts
+++ b/frontend/src/app/services/permissao-pagina.service.ts
@@ -1,0 +1,18 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { PermissaoPagina } from '../models/permissao-pagina';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PermissaoPaginaService {
+
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/paginas';
+
+  findAll(): Observable<PermissaoPagina[]> {
+    return this.http.get<PermissaoPagina[]>(this.API + '/findAll');
+  }
+
+}


### PR DESCRIPTION
## Summary
- add repository, service, and controller for `PermissaoPagina`
- allow `PermissaoGrupo` model to hold selected pages
- create service and model on Angular for `PermissaoPagina`
- extend group details component with page checkboxes
- provide sample SQL script with page permissions

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab00d7d3c832096596d7c015fb293