### PR TITLE
Fix entity name conflict

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/auth/Usuario.java
+++ b/backend/src/main/java/com/sentinel/backend/auth/Usuario.java
@@ -17,7 +17,10 @@ import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.Setter;
 
-@Entity
+import jakarta.persistence.Table;
+
+@Entity(name = "UsuarioAuth")
+@Table(name = "usuario_auth")
 @Getter
 @Setter
 public class Usuario implements UserDetails {


### PR DESCRIPTION
## Summary
- fix startup failure by giving the auth `Usuario` entity a unique name

## Testing
- `mvnw test` *(fails: could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685ab5d574b0832085035929efaf2f81