### PR TITLE
Fix login user lookup

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/auth/LoginService.java
+++ b/backend/src/main/java/com/sentinel/backend/auth/LoginService.java
@@ -3,6 +3,7 @@ package com.sentinel.backend.auth;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.sentinel.backend.config.JwtServiceGenerator;
@@ -29,7 +30,9 @@ public class LoginService {
 				new UsernamePasswordAuthenticationToken(
 						login.getEmail(),
 						login.getSenha()));
-		Usuario user = repository.findByUsername(login.getSenha()).get();
+                Usuario user = repository
+                                .findByUsername(login.getEmail())
+                                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
 		String jwtToken = jwtService.generateToken(user);
 		return jwtToken;
 	}


### PR DESCRIPTION
## Summary
- lookup user by email instead of password in LoginService to allow authentication

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685e9346244483209ecce80d2af13a5d