### PR TITLE
Add initial admin user

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -23,3 +23,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 #Exibição SQL
 spring.jpa.show-sql=true
 
+
+spring.sql.init.mode=always
+

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,3 @@
+INSERT INTO permissoes_grupo (nome) VALUES ('ADMIN');
+INSERT INTO usuario_auth (username, password, role) VALUES ('admin@example.com', '$2b$10$dbqs8pL80Nb/xPZ6XTD2zu.1StJ7vu0AgynHl3v3s3E.cQ/Gc6LxG', 'ADMIN');
+INSERT INTO usuarios (nome, email, senha, permissao_grupo_id) VALUES ('Administrador', 'admin@example.com', '$2b$10$dbqs8pL80Nb/xPZ6XTD2zu.1StJ7vu0AgynHl3v3s3E.cQ/Gc6LxG', 1);


### PR DESCRIPTION
## Summary
- seed database with a default admin user
- ensure data.sql runs on startup

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685ea7a465d48320bd45e2d3ff5dd05c