### PR TITLE
Fix duplicate user creation

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/auth/Usuario.java
+++ b/backend/src/main/java/com/sentinel/backend/auth/Usuario.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Column;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,10 +28,13 @@ public class Usuario implements UserDetails {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-	private String username;
-	private String password;
-	private String role;
+        private Long id;
+
+        @Column(unique = true, nullable = false)
+        private String username;
+
+        private String password;
+        private String role;
 
 	@Override
 	@JsonIgnore

--- a/backend/src/main/java/com/sentinel/backend/entity/Usuario.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/Usuario.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Column;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -21,7 +22,10 @@ public class Usuario {
     private Long id;
 
     private String nome;
+
+    @Column(unique = true, nullable = false)
     private String email;
+
     private String senha;
 
     @ManyToOne

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,3 +1,3 @@
-INSERT INTO permissoes_grupo (nome) VALUES ('ADMIN');
-INSERT INTO usuario_auth (username, password, role) VALUES ('admin@example.com', '$2b$10$dbqs8pL80Nb/xPZ6XTD2zu.1StJ7vu0AgynHl3v3s3E.cQ/Gc6LxG', 'ADMIN');
-INSERT INTO usuarios (nome, email, senha, permissao_grupo_id) VALUES ('Administrador', 'admin@example.com', '$2b$10$dbqs8pL80Nb/xPZ6XTD2zu.1StJ7vu0AgynHl3v3s3E.cQ/Gc6LxG', 1);
+INSERT IGNORE INTO permissoes_grupo (nome) VALUES ('ADMIN');
+INSERT IGNORE INTO usuario_auth (username, password, role) VALUES ('admin@example.com', '$2b$10$dbqs8pL80Nb/xPZ6XTD2zu.1StJ7vu0AgynHl3v3s3E.cQ/Gc6LxG', 'ADMIN');
+INSERT IGNORE INTO usuarios (nome, email, senha, permissao_grupo_id) VALUES ('Administrador', 'admin@example.com', '$2b$10$dbqs8pL80Nb/xPZ6XTD2zu.1StJ7vu0AgynHl3v3s3E.cQ/Gc6LxG', 1);


### PR DESCRIPTION
## Summary
- enforce unique constraint on usernames and emails
- ignore duplicate records in initial `data.sql`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685edd07e65883209009f53d3ac2bb55