### PR TITLE
Fix authentication error

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/config/SecurityManager.java
+++ b/backend/src/main/java/com/sentinel/backend/config/SecurityManager.java
@@ -13,6 +13,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.sentinel.backend.repository.UsuarioRepository;
+import com.sentinel.backend.config.UsuarioDetails;
 
 @Configuration
 public class SecurityManager {
@@ -41,6 +42,7 @@ public class SecurityManager {
 	@Bean
        public UserDetailsService userDetailsService() {
                return username -> usuarioRepository.findByEmail(username)
+                               .map(UsuarioDetails::new)
                                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
        }
 

--- a/backend/src/main/java/com/sentinel/backend/config/UsuarioDetails.java
+++ b/backend/src/main/java/com/sentinel/backend/config/UsuarioDetails.java
@@ -1,0 +1,66 @@
+package com.sentinel.backend.config;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.sentinel.backend.entity.Usuario;
+
+public class UsuarioDetails implements UserDetails {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Usuario usuario;
+
+    public UsuarioDetails(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        if (usuario.getPermissaoGrupo() == null || usuario.getPermissaoGrupo().getPermissoes() == null) {
+            return Collections.emptyList();
+        }
+        return usuario.getPermissaoGrupo().getPermissoes().stream()
+                .map(p -> new SimpleGrantedAuthority(p.getNome()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return usuario.getSenha();
+    }
+
+    @Override
+    public String getUsername() {
+        return usuario.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `UsuarioDetails` so `Usuario` can adapt to the `UserDetails` API
- return `UsuarioDetails` from `SecurityManager.userDetailsService`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685eecb6012883209c795e4c612b3562