### PR TITLE
Implement permission-based visibility in Angular UI

### DIFF
--- a/frontend/src/app/components/alunos/alunoslist/alunoslist.component.html
+++ b/frontend/src/app/components/alunos/alunoslist/alunoslist.component.html
@@ -5,7 +5,7 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center mb-4">
             <h5 class="card-title mb-0">Alunos</h5>
-            <button type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/alunos/new">
+            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/alunos/new">
               <i class="fas fa-plus me-1"></i> Novo Aluno
             </button>
           </div>

--- a/frontend/src/app/components/alunos/alunoslist/alunoslist.component.ts
+++ b/frontend/src/app/components/alunos/alunoslist/alunoslist.component.ts
@@ -6,6 +6,7 @@ import { ColDef, GridApi, GridOptions, GridReadyEvent } from 'ag-grid-community'
 import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
 import { Aluno } from '../../../models/aluno';
 import { AlunosService } from '../../../services/alunos.service';
+import { UsuariosService } from '../../../services/usuarios.service';
 import Swal from 'sweetalert2';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -62,16 +63,20 @@ export class AlunoslistComponent {
       headerName: 'Ações',
       cellRenderer: (params: any) => {
         const aluno = params.data;
+        const editBtn = this.canEdit ?
+          `<button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${aluno.id}">
+            <i class="fas fa-edit"></i>
+          </button>` : '';
+        const delBtn = this.canDelete ?
+          `<button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${aluno.id}">
+            <i class="fas fa-trash-alt"></i>
+          </button>` : '';
         return `
           <button type="button" class="btn btn-info btn-rounded btn-sm btn-icon" data-action="view" data-id="${aluno.id}">
             <i class="fas fa-eye"></i>
           </button>
-          <button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${aluno.id}">
-            <i class="fas fa-edit"></i>
-          </button>
-          <button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${aluno.id}">
-            <i class="fas fa-trash-alt"></i>
-          </button>
+          ${editBtn}
+          ${delBtn}
         `;
       },
       sortable: false,
@@ -90,6 +95,19 @@ export class AlunoslistComponent {
   rowData: Aluno[] = [];
   alunosService = inject(AlunosService);
   router = inject(Router);
+  usuariosService = inject(UsuariosService);
+
+  get canAdd() {
+    return this.usuariosService.hasPermission('/alunos', 'POST');
+  }
+
+  get canEdit() {
+    return this.usuariosService.hasPermission('/alunos', 'PUT');
+  }
+
+  get canDelete() {
+    return this.usuariosService.hasPermission('/alunos', 'DELETE');
+  }
 
   constructor() {
     this.findAll();

--- a/frontend/src/app/components/layout/login/login.component.ts
+++ b/frontend/src/app/components/layout/login/login.component.ts
@@ -24,7 +24,9 @@ export class LoginComponent {
       next: token => {
         if(token){
           this.usuariosService.addToken(token);
-          this.router.navigate(['/admin/turmas']);
+          this.usuariosService.loadUsuarioLogado().subscribe({
+            next: () => this.router.navigate(['/admin/turmas'])
+          });
         }
       },
       error: erro => {

--- a/frontend/src/app/components/layout/sidebar/sidebar.component.html
+++ b/frontend/src/app/components/layout/sidebar/sidebar.component.html
@@ -24,22 +24,22 @@
     <div class="menu-section">
       <div class="section-title text-center">Cadastros</div>
         <ul class="navbar-nav">
-          <li class="nav-item">
+          <li class="nav-item" *ngIf="hasGet('/alunos')">
             <a class="nav-link" routerLink="/admin/alunos" routerLinkActive="active">
               <i class="fas fa-user-graduate"></i> Alunos
             </a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item" *ngIf="hasGet('/turmas')">
             <a class="nav-link" routerLink="/admin/turmas" routerLinkActive="active">
               <i class="fas fa-chalkboard"></i> Turmas
             </a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item" *ngIf="hasGet('/usuarios')">
             <a class="nav-link" routerLink="/admin/usuarios" routerLinkActive="active">
               <i class="fas fa-user"></i> Usuários
             </a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item" *ngIf="hasGet('/permissao')">
             <a class="nav-link" routerLink="/admin/permissao" routerLinkActive="active">
               <i class="fas fa-users-cog"></i> Permissão Grupo
             </a>

--- a/frontend/src/app/components/layout/sidebar/sidebar.component.ts
+++ b/frontend/src/app/components/layout/sidebar/sidebar.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
+import { UsuariosService } from '../../../services/usuarios.service';
 
 @Component({
   selector: 'app-sidebar',
@@ -9,4 +10,9 @@ import { RouterLink, RouterLinkActive } from '@angular/router';
 })
 export class SidebarComponent {
 
+  usuariosService = inject(UsuariosService);
+
+  hasGet(rota: string) {
+    return this.usuariosService.hasPermission(rota, 'GET');
+  }
 }

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.html
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.html
@@ -5,7 +5,7 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center mb-4">
             <h5 class="card-title mb-0">Permissão Grupo</h5>
-            <button type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/permissao/new">
+            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/permissao/new">
               <i class="fas fa-plus me-1"></i> Novo Grupo
             </button>
           </div>

--- a/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.ts
+++ b/frontend/src/app/components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component.ts
@@ -7,6 +7,7 @@ import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
 import Swal from 'sweetalert2';
 import { PermissaoGrupo } from '../../../models/permissao-grupo';
 import { PermissaoGrupoService } from '../../../services/permissao-grupo.service';
+import { UsuariosService } from '../../../services/usuarios.service';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
@@ -46,16 +47,20 @@ export class PermissaoGrupoListComponent {
       headerName: 'Ações',
       cellRenderer: (params: any) => {
         const pg = params.data;
+        const editBtn = this.canEdit ?
+          `<button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${pg.id}">
+            <i class="fas fa-edit"></i>
+          </button>` : '';
+        const delBtn = this.canDelete ?
+          `<button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${pg.id}">
+            <i class="fas fa-trash-alt"></i>
+          </button>` : '';
         return `
           <button type="button" class="btn btn-info btn-rounded btn-sm btn-icon" data-action="view" data-id="${pg.id}">
             <i class="fas fa-eye"></i>
           </button>
-          <button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${pg.id}">
-            <i class="fas fa-edit"></i>
-          </button>
-          <button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${pg.id}">
-            <i class="fas fa-trash-alt"></i>
-          </button>
+          ${editBtn}
+          ${delBtn}
         `;
       },
       sortable: false,
@@ -74,6 +79,11 @@ export class PermissaoGrupoListComponent {
   rowData: PermissaoGrupo[] = [];
   pgService = inject(PermissaoGrupoService);
   router = inject(Router);
+  usuariosService = inject(UsuariosService);
+
+  get canAdd() { return this.usuariosService.hasPermission('/permissao','POST'); }
+  get canEdit() { return this.usuariosService.hasPermission('/permissao','PUT'); }
+  get canDelete() { return this.usuariosService.hasPermission('/permissao','DELETE'); }
 
   constructor() {
     this.findAll();

--- a/frontend/src/app/components/turmas/turmaslist/turmaslist.component.html
+++ b/frontend/src/app/components/turmas/turmaslist/turmaslist.component.html
@@ -5,7 +5,7 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center mb-4">
             <h5 class="card-title mb-0">Turmas</h5>
-            <button type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/turmas/new">
+            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/turmas/new">
               <i class="fas fa-plus me-1"></i> Nova Turma
             </button>
           </div>

--- a/frontend/src/app/components/turmas/turmaslist/turmaslist.component.ts
+++ b/frontend/src/app/components/turmas/turmaslist/turmaslist.component.ts
@@ -8,6 +8,7 @@ import { AgGridModule } from 'ag-grid-angular';
 import { MdbRippleModule } from 'mdb-angular-ui-kit/ripple';
 import { ModuleRegistry } from 'ag-grid-community';
 import { AllCommunityModule } from 'ag-grid-community';
+import { UsuariosService } from '../../../services/usuarios.service';
 
 
 // Registra todos os módulos da versão Community
@@ -81,16 +82,20 @@ export class TurmaslistComponent {
       headerName: 'Ações',
       cellRenderer: (params: any) => {
         const turma = params.data;
+        const editBtn = this.canEdit ?
+          `<button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${turma.id}">
+            <i class="fas fa-edit"></i>
+          </button>` : '';
+        const delBtn = this.canDelete ?
+          `<button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${turma.id}">
+            <i class="fas fa-trash-alt"></i>
+          </button>` : '';
         return `
           <button type="button" class="btn btn-info btn-rounded btn-sm btn-icon" data-action="view" data-id="${turma.id}">
             <i class="fas fa-eye"></i>
           </button>
-          <button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${turma.id}">
-            <i class="fas fa-edit"></i>
-          </button>
-           <button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${turma.id}">
-            <i class="fas fa-trash-alt"></i>
-          </button>
+          ${editBtn}
+          ${delBtn}
         `;
       },
       sortable: false,
@@ -109,6 +114,11 @@ export class TurmaslistComponent {
   rowData: Turma[] = [];
   turmasService = inject(TurmasService);
   router = inject(Router);
+  usuariosService = inject(UsuariosService);
+
+  get canAdd() { return this.usuariosService.hasPermission('/turmas','POST'); }
+  get canEdit() { return this.usuariosService.hasPermission('/turmas','PUT'); }
+  get canDelete() { return this.usuariosService.hasPermission('/turmas','DELETE'); }
 
   constructor() {
     this.findAll();

--- a/frontend/src/app/components/usuarios/usuarioslist/usuarioslist.component.html
+++ b/frontend/src/app/components/usuarios/usuarioslist/usuarioslist.component.html
@@ -5,7 +5,7 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center mb-4">
             <h5 class="card-title mb-0">Usuários</h5>
-            <button type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/usuarios/new">
+            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/usuarios/new">
               <i class="fas fa-plus me-1"></i> Novo Usuário
             </button>
           </div>

--- a/frontend/src/app/components/usuarios/usuarioslist/usuarioslist.component.ts
+++ b/frontend/src/app/components/usuarios/usuarioslist/usuarioslist.component.ts
@@ -54,16 +54,20 @@ export class UsuarioslistComponent {
       headerName: 'Ações',
       cellRenderer: (params: any) => {
         const usuario = params.data;
+        const editBtn = this.canEdit ?
+          `<button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${usuario.id}">
+            <i class="fas fa-edit"></i>
+          </button>` : '';
+        const delBtn = this.canDelete ?
+          `<button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${usuario.id}">
+            <i class="fas fa-trash-alt"></i>
+          </button>` : '';
         return `
           <button type="button" class="btn btn-info btn-rounded btn-sm btn-icon" data-action="view" data-id="${usuario.id}">
             <i class="fas fa-eye"></i>
           </button>
-          <button type="button" class="btn btn-warning btn-rounded btn-sm btn-icon" data-action="edit" data-id="${usuario.id}">
-            <i class="fas fa-edit"></i>
-          </button>
-          <button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${usuario.id}">
-            <i class="fas fa-trash-alt"></i>
-          </button>
+          ${editBtn}
+          ${delBtn}
         `;
       },
       sortable: false,
@@ -82,6 +86,10 @@ export class UsuarioslistComponent {
   rowData: Usuario[] = [];
   usuariosService = inject(UsuariosService);
   router = inject(Router);
+
+  get canAdd() { return this.usuariosService.hasPermission('/usuarios','POST'); }
+  get canEdit() { return this.usuariosService.hasPermission('/usuarios','PUT'); }
+  get canDelete() { return this.usuariosService.hasPermission('/usuarios','DELETE'); }
 
   constructor() {
     this.findAll();

--- a/frontend/src/app/services/usuarios.service.ts
+++ b/frontend/src/app/services/usuarios.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
 
 import { Usuario } from '../models/usuario';
@@ -14,6 +14,8 @@ export class UsuariosService {
   private readonly http = inject(HttpClient);
   private readonly API = 'http://localhost:8080/usuarios';
   private readonly API_LOGIN = 'http://localhost:8080/api/login';
+
+  private usuarioLogado: Usuario | null = null;
 
   findAll(): Observable<Usuario[]> {
     return this.http.get<Usuario[]>(this.API + '/findAll');
@@ -39,6 +41,19 @@ export class UsuariosService {
     return this.http.post<string>(this.API_LOGIN, login, { responseType: 'text' as 'json' });
   }
 
+  loadUsuarioLogado(): Observable<Usuario> {
+    const payload = this.decodeToken() as any;
+    const id = payload?.id;
+    return this.findById(Number(id)).pipe(
+      tap(u => this.setUsuarioLogado(u))
+    );
+  }
+
+  setUsuarioLogado(usuario: Usuario) {
+    this.usuarioLogado = usuario;
+    localStorage.setItem('usuarioLogado', JSON.stringify(usuario));
+  }
+
   addToken(token: string) {
     localStorage.setItem('token', token);
   }
@@ -49,6 +64,18 @@ export class UsuariosService {
 
   getToken() {
     return localStorage.getItem('token');
+  }
+
+  getUsuarioLogado(): Usuario | null {
+    if (this.usuarioLogado) {
+      return this.usuarioLogado;
+    }
+    const stored = localStorage.getItem('usuarioLogado');
+    if (stored) {
+      this.usuarioLogado = JSON.parse(stored);
+      return this.usuarioLogado;
+    }
+    return null;
   }
 
   decodeToken(): JwtPayload | null {
@@ -67,7 +94,12 @@ export class UsuariosService {
       return false;
   }
 
-  getUsuarioLogado() {
-    return this.decodeToken() as unknown as Usuario;
+  hasPermission(rota: string, metodo: string) {
+    const usuario = this.getUsuarioLogado();
+    const permissoes = usuario?.permissaoGrupo?.permissoes;
+    if (!permissoes) {
+      return false;
+    }
+    return permissoes.some(p => rota.startsWith(p.rota) && p.metodoHttp.toUpperCase() === metodo.toUpperCase());
   }
 }


### PR DESCRIPTION
## Summary
- load user permissions on login and store locally
- expose helpers in `UsuariosService` to check page permissions
- update sidebar to hide menu items if GET access is missing
- hide add/edit/delete buttons in list components when user lacks respective permissions

## Testing
- `npm test --silent` *(fails: Chrome browser not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862939229e883208c791ed8a67eac06