### PR TITLE
Fix login failure due to expired token

### DIFF
--- a/frontend/src/app/auth/http-interceptor.service.ts
+++ b/frontend/src/app/auth/http-interceptor.service.ts
@@ -8,10 +8,14 @@ export const meuhttpInterceptor: HttpInterceptorFn = (request, next) => {
 
   let router = inject(Router);
 
-  let token = localStorage.getItem('token');
-  
+  const token = localStorage.getItem('token');
+
   console.log('entrou aqui 1');
-  if (token) {
+  if (
+    token &&
+    !request.url.includes('/api/login') &&
+    !request.url.includes('/api/register')
+  ) {
     request = request.clone({
       setHeaders: { Authorization: 'Bearer ' + token },
     });


### PR DESCRIPTION
## Summary
- ensure the HTTP interceptor skips Authorization header on login/register

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*
- `./mvnw test -q` *(fails: Could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6862c81698f48320bff74bdf38fe26f5