### PR TITLE
Enable universal access for findById

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/config/PermissionFilter.java
+++ b/backend/src/main/java/com/sentinel/backend/config/PermissionFilter.java
@@ -33,6 +33,13 @@ public class PermissionFilter extends OncePerRequestFilter {
             if (usuario != null && usuario.getPermissaoGrupo() != null) {
                 String path = request.getRequestURI();
                 String method = request.getMethod();
+
+                // allow findById for all authenticated users
+                if (path.startsWith("/usuarios/findById") && method.equalsIgnoreCase("GET")) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 boolean allowed = usuario.getPermissaoGrupo().getPermissoes().stream()
                         .anyMatch(p -> path.startsWith(p.getRota()) && method.equalsIgnoreCase(p.getMetodoHttp()));
                 if (!allowed) {


### PR DESCRIPTION
## Summary
- allow GET `/usuarios/findById` for any authenticated user

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863deebc11083208d93596ad99164b3