### PR TITLE
Add home page and user dropdown

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -9,12 +9,16 @@ import { UsuarioslistComponent } from './components/usuarios/usuarioslist/usuari
 import { UsuariosdetailsComponent } from './components/usuarios/usuariosdetails/usuariosdetails.component';
 import { PermissaoGrupoListComponent } from './components/permissao-grupo/permissao-grupo-list/permissao-grupo-list.component';
 import { PermissaoGrupoDetailsComponent } from './components/permissao-grupo/permissao-grupo-details/permissao-grupo-details.component';
+import { HomeComponent } from './components/home/home.component';
+import { RedirectComponent } from './components/layout/redirect/redirect.component';
 
 
 export const routes: Routes = [
-  {path: "", redirectTo: "login", pathMatch: 'full'},
-  {path: "login", component: LoginComponent},
-
+  { path: '', component: RedirectComponent },
+  { path: 'login', component: LoginComponent },
+  { path: 'home', component: PrincipalComponent, children: [
+    { path: '', component: HomeComponent }
+  ]},
   {path: "admin", component: PrincipalComponent, children:[
     {path: "turmas", component: TurmaslistComponent},
     {path: "turmas/new", component: TurmasdetailsComponent},
@@ -30,6 +34,5 @@ export const routes: Routes = [
     {path: "permissao/edit/:id", component: PermissaoGrupoDetailsComponent}
 
   ]},
-
-
+  { path: '**', redirectTo: '' }
 ];

--- a/frontend/src/app/components/home/home.component.css
+++ b/frontend/src/app/components/home/home.component.css
@@ -1,0 +1,1 @@
+/* Estilos da página inicial */

--- a/frontend/src/app/components/home/home.component.html
+++ b/frontend/src/app/components/home/home.component.html
@@ -1,0 +1,3 @@
+<div class="p-4">
+  <h3>Bem-vindo!</h3>
+</div>

--- a/frontend/src/app/components/home/home.component.ts
+++ b/frontend/src/app/components/home/home.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-home',
+  standalone: true,
+  templateUrl: './home.component.html',
+  styleUrl: './home.component.css'
+})
+export class HomeComponent {}
+

--- a/frontend/src/app/components/layout/login/login.component.ts
+++ b/frontend/src/app/components/layout/login/login.component.ts
@@ -25,7 +25,7 @@ export class LoginComponent {
         if(token){
           this.usuariosService.addToken(token);
           this.usuariosService.loadUsuarioLogado().subscribe({
-            next: () => this.router.navigate(['/admin/turmas'])
+            next: () => this.router.navigate(['/home'])
           });
         }
       },

--- a/frontend/src/app/components/layout/menu/menu.component.css
+++ b/frontend/src/app/components/layout/menu/menu.component.css
@@ -9,3 +9,8 @@
   height: 50px;
   border-bottom: 2px solid #FFC107;
 }
+
+.navbar .nav-link {
+  cursor: pointer;
+  color: #fff;
+}

--- a/frontend/src/app/components/layout/menu/menu.component.html
+++ b/frontend/src/app/components/layout/menu/menu.component.html
@@ -1,6 +1,12 @@
-<!-- Image and text -->
 <nav class="navbar">
   <div class="container-fluid">
-
+    <div class="dropdown ms-auto" [class.show]="open" (click)="toggleDropdown()">
+      <a class="nav-link dropdown-toggle text-white" role="button">
+        {{ nomeUsuario }}
+      </a>
+      <ul class="dropdown-menu dropdown-menu-end" [class.show]="open">
+        <li><a class="dropdown-item" (click)="logout()">Sair</a></li>
+      </ul>
+    </div>
   </div>
 </nav>

--- a/frontend/src/app/components/layout/menu/menu.component.ts
+++ b/frontend/src/app/components/layout/menu/menu.component.ts
@@ -1,11 +1,30 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { UsuariosService } from '../../services/usuarios.service';
 
 @Component({
   selector: 'app-menu',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './menu.component.html',
   styleUrl: './menu.component.css'
 })
 export class MenuComponent {
+  private usuariosService = inject(UsuariosService);
+  private router = inject(Router);
+  open = false;
 
+  get nomeUsuario(): string {
+    return this.usuariosService.getUsuarioLogado()?.nome || '';
+  }
+
+  toggleDropdown() {
+    this.open = !this.open;
+  }
+
+  logout() {
+    this.usuariosService.logout();
+    this.router.navigate(['/login']);
+  }
 }

--- a/frontend/src/app/components/layout/redirect/redirect.component.ts
+++ b/frontend/src/app/components/layout/redirect/redirect.component.ts
@@ -1,0 +1,22 @@
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { UsuariosService } from '../../../services/usuarios.service';
+
+@Component({
+  selector: 'app-redirect',
+  standalone: true,
+  template: ''
+})
+export class RedirectComponent {
+  private router = inject(Router);
+  private usuariosService = inject(UsuariosService);
+
+  ngOnInit() {
+    if (this.usuariosService.getToken()) {
+      this.router.navigate(['/home']);
+    } else {
+      this.router.navigate(['/login']);
+    }
+  }
+}
+

--- a/frontend/src/app/components/layout/sidebar/sidebar.component.html
+++ b/frontend/src/app/components/layout/sidebar/sidebar.component.html
@@ -15,7 +15,7 @@
   <!-- Menu de navegação -->
   <ul class="navbar-nav">
       <li class="nav-item">
-        <a class="nav-link active" aria-current="page" href="#">
+        <a class="nav-link" routerLink="/home" routerLinkActive="active">
           <i class="fas fa-home"></i> Home
         </a>
       </li>

--- a/frontend/src/app/services/usuarios.service.ts
+++ b/frontend/src/app/services/usuarios.service.ts
@@ -62,6 +62,12 @@ export class UsuariosService {
     localStorage.removeItem('token');
   }
 
+  logout() {
+    this.removerToken();
+    localStorage.removeItem('usuarioLogado');
+    this.usuarioLogado = null;
+  }
+
   getToken() {
     return localStorage.getItem('token');
   }


### PR DESCRIPTION
## Summary
- create blank home component and redirect component
- show logged user name with logout dropdown in menu
- update sidebar link for /home
- send user to `/home` after login
- route root to login or home based on token
- expose logout method in user service

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e4991b9083208a967b4b5a975b84