### PR TITLE
Fix user menu dropdown visibility

### DIFF
--- a/frontend/src/app/components/layout/menu/menu.component.html
+++ b/frontend/src/app/components/layout/menu/menu.component.html
@@ -4,7 +4,7 @@
       <a class="nav-link dropdown-toggle text-white" role="button">
         {{ nomeUsuario }}
       </a>
-      <ul class="dropdown-menu dropdown-menu-end" [class.show]="open">
+      <ul *ngIf="open" class="dropdown-menu dropdown-menu-end">
         <li><a class="dropdown-item" (click)="logout()">Sair</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- hide logout menu until user clicks username

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ed29d3f48320bf09690058c6218d