### PR TITLE
Add user icon and dropdown

### DIFF
--- a/frontend/src/app/components/layout/menu/menu.component.css
+++ b/frontend/src/app/components/layout/menu/menu.component.css
@@ -14,3 +14,9 @@
   cursor: pointer;
   color: #fff;
 }
+
+.user-icon {
+  cursor: pointer;
+  color: #fff;
+  font-size: 1.2rem;
+}

--- a/frontend/src/app/components/layout/menu/menu.component.html
+++ b/frontend/src/app/components/layout/menu/menu.component.html
@@ -1,12 +1,15 @@
 <nav class="navbar">
   <div class="container-fluid">
-    <div class="dropdown ms-auto" [class.show]="open" (click)="toggleDropdown()">
-      <a class="nav-link dropdown-toggle text-white" role="button">
-        {{ nomeUsuario }}
-      </a>
-      <ul *ngIf="open" class="dropdown-menu dropdown-menu-end">
-        <li><a class="dropdown-item" (click)="logout()">Sair</a></li>
-      </ul>
+    <div class="ms-auto d-flex align-items-center">
+      <span class="text-white me-2">{{ nomeUsuario }}</span>
+      <div class="dropdown" [class.show]="open">
+        <a class="nav-link user-icon" role="button" (click)="toggleDropdown()">
+          <i class="fas fa-user"></i>
+        </a>
+        <ul *ngIf="open" class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item" (click)="logout()">Sair</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- add icon in menu
- link dropdown logout to icon instead of username

## Testing
- `npm install`
- `npx ng test --watch=false` *(fails: Module build failed)*

------
https://chatgpt.com/codex/tasks/task_e_6863ef4c26008320a3f6927bfe1f6356