### PR TITLE
Fix dropdown menu shifting

### DIFF
--- a/frontend/src/app/components/layout/menu/menu.component.css
+++ b/frontend/src/app/components/layout/menu/menu.component.css
@@ -20,3 +20,13 @@
   color: #fff;
   font-size: 1.2rem;
 }
+
+/* Ensure dropdown does not shift surrounding elements */
+.dropdown {
+  position: relative;
+}
+
+.dropdown-menu {
+  position: absolute;
+  right: 0;
+}


### PR DESCRIPTION
## Summary
- prevent dropdown from shifting the username

## Testing
- `npm test -- --watch=false` *(fails: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_6863f105ede4832099c6334942951ab4