### PR TITLE
Add menu items and permissions for Cargo and Disciplina

### DIFF
--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -23,9 +23,18 @@ INSERT IGNORE INTO permissoes_pagina (id, nome, rota, metodo_http) VALUES
   (17, 'Alunos - Listar', '/alunos', 'GET'),
   (18, 'Alunos - Criar', '/alunos', 'POST'),
   (19, 'Alunos - Atualizar', '/alunos', 'PUT'),
-  (20, 'Alunos - Remover', '/alunos', 'DELETE');
+  (20, 'Alunos - Remover', '/alunos', 'DELETE'),
+  (21, 'Cargo Funcionário - Listar', '/cargos', 'GET'),
+  (22, 'Cargo Funcionário - Criar', '/cargos', 'POST'),
+  (23, 'Cargo Funcionário - Atualizar', '/cargos', 'PUT'),
+  (24, 'Cargo Funcionário - Remover', '/cargos', 'DELETE'),
+  (25, 'Disciplina - Listar', '/disciplinas', 'GET'),
+  (26, 'Disciplina - Criar', '/disciplinas', 'POST'),
+  (27, 'Disciplina - Atualizar', '/disciplinas', 'PUT'),
+  (28, 'Disciplina - Remover', '/disciplinas', 'DELETE');
 
 -- Vincula todas as páginas ao grupo ADMIN
 INSERT IGNORE INTO grupo_paginas (grupo_id, pagina_id) VALUES
   (1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8),(1,9),(1,10),
-  (1,11),(1,12),(1,13),(1,14),(1,15),(1,16),(1,17),(1,18),(1,19),(1,20);
+  (1,11),(1,12),(1,13),(1,14),(1,15),(1,16),(1,17),(1,18),(1,19),(1,20),
+  (1,21),(1,22),(1,23),(1,24),(1,25),(1,26),(1,27),(1,28);

--- a/frontend/src/app/components/layout/sidebar/sidebar.component.html
+++ b/frontend/src/app/components/layout/sidebar/sidebar.component.html
@@ -39,6 +39,16 @@
               <i class="fas fa-user"></i> Usuários
             </a>
           </li>
+          <li class="nav-item" *ngIf="hasGet('/cargos')">
+            <a class="nav-link" routerLink="/admin/cargos" routerLinkActive="active">
+              <i class="fas fa-briefcase"></i> Cargo Funcionário
+            </a>
+          </li>
+          <li class="nav-item" *ngIf="hasGet('/disciplinas')">
+            <a class="nav-link" routerLink="/admin/disciplinas" routerLinkActive="active">
+              <i class="fas fa-book"></i> Disciplinas
+            </a>
+          </li>
           <li class="nav-item" *ngIf="hasGet('/permissao')">
             <a class="nav-link" routerLink="/admin/permissao" routerLinkActive="active">
               <i class="fas fa-users-cog"></i> Permissão Grupo


### PR DESCRIPTION
## Summary
- add Cargo/Disciplina permissions to data.sql
- link new pages to ADMIN group
- display Cargo Funcionário and Disciplinas in sidebar

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68652e9318a4832090cefdbc415c5a58