### PR TITLE
Fix funcionario status handling

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/entity/Funcionario.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/Funcionario.java
@@ -39,7 +39,7 @@ public class Funcionario {
     private String estado;
     private Date admissao;
     private Date demissao;
-    private String Status;
+    private String status;
 
     @ManyToOne
     @JoinColumn(name = "cargos_id")

--- a/backend/src/main/java/com/sentinel/backend/service/FuncionarioService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/FuncionarioService.java
@@ -63,10 +63,10 @@ public class FuncionarioService {
             return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
         }
 
-        if (acao.equalsIgnoreCase("cadastrar")) {
-            funcionario.setStatus("ATIVO");
-        } else if (funcionario.getDemissao() != null) {
+        if (funcionario.getDemissao() != null) {
             funcionario.setStatus("INATIVO");
+        } else {
+            funcionario.setStatus("ATIVO");
         }
 
         if (acao.equalsIgnoreCase("cadastrar")) {

--- a/frontend/src/app/components/funcionarios/funcionarioslist/funcionarioslist.component.ts
+++ b/frontend/src/app/components/funcionarios/funcionarioslist/funcionarioslist.component.ts
@@ -47,7 +47,7 @@ export class FuncionarioslistComponent {
     { field: 'email', headerName: 'Email', filter: 'agTextColumnFilter', floatingFilter: true },
     { field: 'telefone', headerName: 'Telefone', filter: 'agTextColumnFilter', floatingFilter: true },
     { field: 'cargo.nome', headerName: 'Cargo', valueGetter: params => params.data?.cargo?.nome, filter: 'agTextColumnFilter', floatingFilter: true },
-    { field: 'Status', headerName: 'Status', filter: 'agTextColumnFilter', floatingFilter: true },
+    { field: 'status', headerName: 'Status', filter: 'agTextColumnFilter', floatingFilter: true },
     {
       headerName: 'Ações',
       cellRenderer: (params: any) => {
@@ -135,10 +135,10 @@ export class FuncionarioslistComponent {
   viewById(id: number) {
     const funcionario = this.rowData.find(c => c.id === id);
     if (funcionario) {
-      Swal.fire({
-        title: 'Funcionário',
-        html: `<p><strong>Nome:</strong> ${funcionario.nome}</p><p><strong>Email:</strong> ${funcionario.email}</p><p><strong>Cargo:</strong> ${funcionario.cargo?.nome || ''}</p><p><strong>Status:</strong> ${funcionario.Status}</p>`,
-        icon: 'info'
+        Swal.fire({
+          title: 'Funcionário',
+          html: `<p><strong>Nome:</strong> ${funcionario.nome}</p><p><strong>Email:</strong> ${funcionario.email}</p><p><strong>Cargo:</strong> ${funcionario.cargo?.nome || ''}</p><p><strong>Status:</strong> ${funcionario.status}</p>`,
+          icon: 'info'
       });
     }
   }

--- a/frontend/src/app/models/funcionario.ts
+++ b/frontend/src/app/models/funcionario.ts
@@ -15,7 +15,7 @@ export class Funcionario {
   estado: string;
   admissao: Date | null;
   demissao: Date | null;
-  Status?: string;
+  status?: string;
   cargo: Cargo | null;
 
   constructor(
@@ -34,7 +34,7 @@ export class Funcionario {
     demissao: Date | null,
     cargo: Cargo | null,
     id?: number,
-    Status?: string
+    status?: string
   ) {
     this.id = id;
     this.nome = nome;
@@ -51,6 +51,6 @@ export class Funcionario {
     this.admissao = admissao;
     this.demissao = demissao;
     this.cargo = cargo;
-    this.Status = Status;
+    this.status = status;
   }
 }


### PR DESCRIPTION
## Summary
- ensure Funcionario entity and model use `status`
- set status to `ATIVO` by default or `INATIVO` when demissao is filled
- show status correctly in FuncionarioslistComponent

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `sh ./mvnw -q test` *(fails: could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68653fff7e6483208ec55e7e6d208da1