### PR TITLE
Add PlanoPagamento entity and related components

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/PlanoPagamentoController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/PlanoPagamentoController.java
@@ -1,0 +1,69 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import com.sentinel.backend.entity.PlanoPagamento;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.service.PlanoPagamentoService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/planos-pagamento")
+@CrossOrigin("*")
+@Slf4j
+public class PlanoPagamentoController {
+
+    @Autowired
+    private PlanoPagamentoService ps;
+
+    @GetMapping("/findAll")
+    public Iterable<PlanoPagamento> listar() {
+        return ps.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return ps.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody PlanoPagamento plano) {
+        return ps.cadastrarAlterar(plano, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody PlanoPagamento plano) {
+        return ps.cadastrarAlterar(plano, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<PlanoPagamento> findById(@PathVariable long id) {
+        log.info("Finding planoPagamento with id {}", id);
+        try {
+            Optional<PlanoPagamento> plano = ps.findById(id);
+            if (plano.isPresent()) {
+                log.info("PlanoPagamento {} found", id);
+                return new ResponseEntity<>(plano.get(), HttpStatus.OK);
+            }
+            log.warn("PlanoPagamento {} not found", id);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            log.error("Error retrieving planoPagamento {}", id, e);
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/entity/PlanoPagamento.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/PlanoPagamento.java
@@ -1,0 +1,31 @@
+package com.sentinel.backend.entity;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "planos_pagamento")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlanoPagamento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String descricao;
+    private int numeroParcelas;
+    private String periodicidade;
+    private BigDecimal valorTotal;
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/PlanoPagamentoRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/PlanoPagamentoRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.PlanoPagamento;
+
+public interface PlanoPagamentoRepository extends JpaRepository<PlanoPagamento, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/service/PlanoPagamentoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/PlanoPagamentoService.java
@@ -1,0 +1,69 @@
+package com.sentinel.backend.service;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.sentinel.backend.entity.PlanoPagamento;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.repository.PlanoPagamentoRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class PlanoPagamentoService {
+
+    @Autowired
+    private PlanoPagamentoRepository pr;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    public Iterable<PlanoPagamento> listar() {
+        return pr.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(PlanoPagamento plano, String acao) {
+        if (plano.getDescricao() == null || plano.getDescricao().isEmpty()) {
+            rm.setMensagem("A descrição do plano é obrigatória!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        } else if (plano.getNumeroParcelas() <= 0) {
+            rm.setMensagem("Número de parcelas deve ser maior que zero!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        } else if (plano.getPeriodicidade() == null || plano.getPeriodicidade().isEmpty()) {
+            rm.setMensagem("A periodicidade é obrigatória!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        } else if (plano.getValorTotal() == null || plano.getValorTotal().compareTo(BigDecimal.ZERO) <= 0) {
+            rm.setMensagem("O valor total é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            return new ResponseEntity<>(pr.save(plano), HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(pr.save(plano), HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!pr.existsById(id)) {
+            rm.setMensagem("Plano de pagamento não encontrado!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+        pr.deleteById(id);
+        rm.setMensagem("Plano de pagamento excluído com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public Optional<PlanoPagamento> findById(long id) {
+        log.debug("Fetching planoPagamento id {}", id);
+        Optional<PlanoPagamento> plano = pr.findById(id);
+        plano.ifPresent(p -> log.debug("Fetched planoPagamento id {}", id));
+        return plano;
+    }
+}


### PR DESCRIPTION
## Summary
- create `PlanoPagamento` entity with JPA annotations
- add `PlanoPagamentoRepository`
- implement service and controller for payment plan CRUD operations

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6867c9c8faf48320a45c9d992461d886