### PR TITLE
Add matricula and parcela modules

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/MatriculaController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/MatriculaController.java
@@ -1,0 +1,69 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.sentinel.backend.entity.Matricula;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.service.MatriculaService;
+
+@RestController
+@RequestMapping("/matriculas")
+@CrossOrigin("*")
+@Slf4j
+public class MatriculaController {
+
+    @Autowired
+    private MatriculaService ms;
+
+    @GetMapping("/findAll")
+    public Iterable<Matricula> listar() {
+        return ms.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return ms.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody Matricula matricula) {
+        return ms.cadastrarAlterar(matricula, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody Matricula matricula) {
+        return ms.cadastrarAlterar(matricula, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<Matricula> findById(@PathVariable long id) {
+        log.info("Finding matricula with id {}", id);
+        try {
+            Optional<Matricula> matricula = ms.findById(id);
+            if (matricula.isPresent()) {
+                log.info("Matricula {} found", id);
+                return new ResponseEntity<>(matricula.get(), HttpStatus.OK);
+            }
+            log.warn("Matricula {} not found", id);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            log.error("Error retrieving matricula {}", id, e);
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/controller/ParcelaController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/ParcelaController.java
@@ -1,0 +1,69 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.sentinel.backend.entity.Parcela;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.service.ParcelaService;
+
+@RestController
+@RequestMapping("/parcelas")
+@CrossOrigin("*")
+@Slf4j
+public class ParcelaController {
+
+    @Autowired
+    private ParcelaService ps;
+
+    @GetMapping("/findAll")
+    public Iterable<Parcela> listar() {
+        return ps.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return ps.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody Parcela parcela) {
+        return ps.cadastrarAlterar(parcela, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody Parcela parcela) {
+        return ps.cadastrarAlterar(parcela, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<Parcela> findById(@PathVariable long id) {
+        log.info("Finding parcela with id {}", id);
+        try {
+            Optional<Parcela> parcela = ps.findById(id);
+            if (parcela.isPresent()) {
+                log.info("Parcela {} found", id);
+                return new ResponseEntity<>(parcela.get(), HttpStatus.OK);
+            }
+            log.warn("Parcela {} not found", id);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            log.error("Error retrieving parcela {}", id, e);
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/entity/Matricula.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/Matricula.java
@@ -1,0 +1,38 @@
+package com.sentinel.backend.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "matriculas")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Matricula {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "aluno_id")
+    private Aluno aluno;
+
+    @ManyToOne
+    @JoinColumn(name = "plano_pagamento_id")
+    private PlanoPagamento planoPagamento;
+
+    @ManyToOne
+    @JoinColumn(name = "turma_id")
+    private Turma turma;
+}

--- a/backend/src/main/java/com/sentinel/backend/entity/Parcela.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/Parcela.java
@@ -1,0 +1,39 @@
+package com.sentinel.backend.entity;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "parcelas")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Parcela {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "matricula_id")
+    private Matricula matricula;
+
+    private int numero;
+    private BigDecimal valorOriginal;
+    private Date dataVencimento;
+    private String status;
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/MatriculaRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/MatriculaRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.Matricula;
+
+public interface MatriculaRepository extends JpaRepository<Matricula, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/ParcelaRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/ParcelaRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.Parcela;
+
+public interface ParcelaRepository extends JpaRepository<Parcela, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/service/MatriculaService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/MatriculaService.java
@@ -1,0 +1,101 @@
+package com.sentinel.backend.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.sentinel.backend.entity.Matricula;
+import com.sentinel.backend.entity.Parcela;
+import com.sentinel.backend.entity.PlanoPagamento;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.repository.MatriculaRepository;
+import com.sentinel.backend.repository.ParcelaRepository;
+
+@Service
+public class MatriculaService {
+
+    @Autowired
+    private MatriculaRepository mr;
+
+    @Autowired
+    private ParcelaRepository parcelaRepository;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    public Iterable<Matricula> listar() {
+        return mr.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(Matricula matricula, String acao) {
+        if (matricula.getAluno() == null) {
+            rm.setMensagem("O aluno é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        } else if (matricula.getPlanoPagamento() == null) {
+            rm.setMensagem("O plano de pagamento é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        } else if (matricula.getTurma() == null) {
+            rm.setMensagem("A turma é obrigatória!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            Matricula saved = mr.save(matricula);
+            gerarParcelas(saved);
+            return new ResponseEntity<>(saved, HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(mr.save(matricula), HttpStatus.OK);
+        }
+    }
+
+    private void gerarParcelas(Matricula matricula) {
+        PlanoPagamento plano = matricula.getPlanoPagamento();
+        int quantidade = plano.getNumeroParcelas();
+        BigDecimal valorParcela = plano.getValorTotal().divide(BigDecimal.valueOf(quantidade));
+        long incremento = getIncrementoMeses(plano.getPeriodicidade());
+        LocalDate vencimento = LocalDate.now();
+        for (int i = 1; i <= quantidade; i++) {
+            Parcela p = new Parcela();
+            p.setMatricula(matricula);
+            p.setNumero(i);
+            p.setValorOriginal(valorParcela);
+            p.setDataVencimento(java.sql.Date.valueOf(vencimento));
+            p.setStatus("ABERTO");
+            parcelaRepository.save(p);
+            vencimento = vencimento.plus(incremento, ChronoUnit.MONTHS);
+        }
+    }
+
+    private long getIncrementoMeses(String periodicidade) {
+        if (periodicidade == null) {
+            return 1L;
+        }
+        return switch (periodicidade.toUpperCase()) {
+            case "BIMESTRAL" -> 2L;
+            case "TRIMESTRAL" -> 3L;
+            case "SEMESTRAL" -> 6L;
+            case "ANUAL" -> 12L;
+            default -> 1L;
+        };
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!mr.existsById(id)) {
+            rm.setMensagem("Matrícula não encontrada!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+        mr.deleteById(id);
+        rm.setMensagem("Matrícula excluída com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public Optional<Matricula> findById(long id) {
+        return mr.findById(id);
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/service/ParcelaService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/ParcelaService.java
@@ -1,0 +1,52 @@
+package com.sentinel.backend.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import com.sentinel.backend.entity.Parcela;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.repository.ParcelaRepository;
+
+@Service
+public class ParcelaService {
+
+    @Autowired
+    private ParcelaRepository pr;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    public Iterable<Parcela> listar() {
+        return pr.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(Parcela parcela, String acao) {
+        if (parcela.getMatricula() == null) {
+            rm.setMensagem("A matrícula é obrigatória!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            return new ResponseEntity<>(pr.save(parcela), HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(pr.save(parcela), HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!pr.existsById(id)) {
+            rm.setMensagem("Parcela não encontrada!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+        pr.deleteById(id);
+        rm.setMensagem("Parcela excluída com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public Optional<Parcela> findById(long id) {
+        return pr.findById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add Matricula and Parcela entities
- create repositories for both entities
- implement services including automatic parcel generation when creating a matricula
- expose new REST controllers under `/matriculas` and `/parcelas`

## Testing
- `mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6867cc50160483209c75119066fe8b20