### PR TITLE
Add financial models and services

### DIFF
--- a/frontend/src/app/models/desconto.ts
+++ b/frontend/src/app/models/desconto.ts
@@ -1,0 +1,24 @@
+import { Parcela } from './parcela';
+import { Pagamento } from './pagamento';
+
+export class Desconto {
+  id?: number;
+  parcela: Parcela | null;
+  pagamento: Pagamento | null;
+  valor: number;
+  motivo: string;
+
+  constructor(
+    parcela: Parcela | null,
+    pagamento: Pagamento | null,
+    valor: number,
+    motivo: string,
+    id?: number
+  ) {
+    this.id = id;
+    this.parcela = parcela;
+    this.pagamento = pagamento;
+    this.valor = valor;
+    this.motivo = motivo;
+  }
+}

--- a/frontend/src/app/models/despesa.ts
+++ b/frontend/src/app/models/despesa.ts
@@ -1,0 +1,21 @@
+export class Despesa {
+  id?: number;
+  descricao: string;
+  valor: number;
+  data: Date | null;
+  categoria: string;
+
+  constructor(
+    descricao: string,
+    valor: number,
+    data: Date | null,
+    categoria: string,
+    id?: number
+  ) {
+    this.id = id;
+    this.descricao = descricao;
+    this.valor = valor;
+    this.data = data;
+    this.categoria = categoria;
+  }
+}

--- a/frontend/src/app/models/lancamento-financeiro.ts
+++ b/frontend/src/app/models/lancamento-financeiro.ts
@@ -1,0 +1,18 @@
+export class LancamentoFinanceiro {
+  id?: number;
+  data: Date | null;
+  saldoDiario: number;
+  saldoMensal: number;
+
+  constructor(
+    data: Date | null,
+    saldoDiario: number,
+    saldoMensal: number,
+    id?: number
+  ) {
+    this.id = id;
+    this.data = data;
+    this.saldoDiario = saldoDiario;
+    this.saldoMensal = saldoMensal;
+  }
+}

--- a/frontend/src/app/models/matricula.ts
+++ b/frontend/src/app/models/matricula.ts
@@ -1,0 +1,22 @@
+import { Aluno } from './aluno';
+import { PlanoPagamento } from './plano-pagamento';
+import { Turma } from './turmas';
+
+export class Matricula {
+  id?: number;
+  aluno: Aluno | null;
+  planoPagamento: PlanoPagamento | null;
+  turma: Turma | null;
+
+  constructor(
+    aluno: Aluno | null,
+    planoPagamento: PlanoPagamento | null,
+    turma: Turma | null,
+    id?: number
+  ) {
+    this.id = id;
+    this.aluno = aluno;
+    this.planoPagamento = planoPagamento;
+    this.turma = turma;
+  }
+}

--- a/frontend/src/app/models/pagamento.ts
+++ b/frontend/src/app/models/pagamento.ts
@@ -1,0 +1,23 @@
+import { Parcela } from './parcela';
+
+export class Pagamento {
+  id?: number;
+  parcela: Parcela | null;
+  dataPagamento: Date | null;
+  valorPago: number;
+  formaPagamento: string;
+
+  constructor(
+    parcela: Parcela | null,
+    dataPagamento: Date | null,
+    valorPago: number,
+    formaPagamento: string,
+    id?: number
+  ) {
+    this.id = id;
+    this.parcela = parcela;
+    this.dataPagamento = dataPagamento;
+    this.valorPago = valorPago;
+    this.formaPagamento = formaPagamento;
+  }
+}

--- a/frontend/src/app/models/parcela.ts
+++ b/frontend/src/app/models/parcela.ts
@@ -1,0 +1,26 @@
+import { Matricula } from './matricula';
+
+export class Parcela {
+  id?: number;
+  matricula: Matricula | null;
+  numero: number;
+  valorOriginal: number;
+  dataVencimento: Date | null;
+  status: string;
+
+  constructor(
+    matricula: Matricula | null,
+    numero: number,
+    valorOriginal: number,
+    dataVencimento: Date | null,
+    status: string,
+    id?: number
+  ) {
+    this.id = id;
+    this.matricula = matricula;
+    this.numero = numero;
+    this.valorOriginal = valorOriginal;
+    this.dataVencimento = dataVencimento;
+    this.status = status;
+  }
+}

--- a/frontend/src/app/models/plano-pagamento.ts
+++ b/frontend/src/app/models/plano-pagamento.ts
@@ -1,0 +1,21 @@
+export class PlanoPagamento {
+  id?: number;
+  descricao: string;
+  numeroParcelas: number;
+  periodicidade: string;
+  valorTotal: number;
+
+  constructor(
+    descricao: string,
+    numeroParcelas: number,
+    periodicidade: string,
+    valorTotal: number,
+    id?: number
+  ) {
+    this.id = id;
+    this.descricao = descricao;
+    this.numeroParcelas = numeroParcelas;
+    this.periodicidade = periodicidade;
+    this.valorTotal = valorTotal;
+  }
+}

--- a/frontend/src/app/models/receita.ts
+++ b/frontend/src/app/models/receita.ts
@@ -1,0 +1,21 @@
+export class Receita {
+  id?: number;
+  descricao: string;
+  valor: number;
+  data: Date | null;
+  categoria: string;
+
+  constructor(
+    descricao: string,
+    valor: number,
+    data: Date | null,
+    categoria: string,
+    id?: number
+  ) {
+    this.id = id;
+    this.descricao = descricao;
+    this.valor = valor;
+    this.data = data;
+    this.categoria = categoria;
+  }
+}

--- a/frontend/src/app/services/desconto.service.ts
+++ b/frontend/src/app/services/desconto.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Desconto } from '../models/desconto';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DescontoService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/descontos';
+
+  findAll(): Observable<Desconto[]> {
+    return this.http.get<Desconto[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(desconto: Desconto): Observable<string> {
+    return this.http.post<string>(this.API + '/save', desconto, { responseType: 'text' as 'json' });
+  }
+
+  update(desconto: Desconto): Observable<string> {
+    return this.http.put<string>(this.API + '/update', desconto, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<Desconto> {
+    return this.http.get<Desconto>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/despesa.service.ts
+++ b/frontend/src/app/services/despesa.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Despesa } from '../models/despesa';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DespesaService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/despesas';
+
+  findAll(): Observable<Despesa[]> {
+    return this.http.get<Despesa[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(despesa: Despesa): Observable<string> {
+    return this.http.post<string>(this.API + '/save', despesa, { responseType: 'text' as 'json' });
+  }
+
+  update(despesa: Despesa): Observable<string> {
+    return this.http.put<string>(this.API + '/update', despesa, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<Despesa> {
+    return this.http.get<Despesa>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/lancamento-financeiro.service.ts
+++ b/frontend/src/app/services/lancamento-financeiro.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { LancamentoFinanceiro } from '../models/lancamento-financeiro';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LancamentoFinanceiroService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/lancamentos-financeiros';
+
+  findAll(): Observable<LancamentoFinanceiro[]> {
+    return this.http.get<LancamentoFinanceiro[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(lancamento: LancamentoFinanceiro): Observable<string> {
+    return this.http.post<string>(this.API + '/save', lancamento, { responseType: 'text' as 'json' });
+  }
+
+  update(lancamento: LancamentoFinanceiro): Observable<string> {
+    return this.http.put<string>(this.API + '/update', lancamento, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<LancamentoFinanceiro> {
+    return this.http.get<LancamentoFinanceiro>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/matricula.service.ts
+++ b/frontend/src/app/services/matricula.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Matricula } from '../models/matricula';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MatriculaService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/matriculas';
+
+  findAll(): Observable<Matricula[]> {
+    return this.http.get<Matricula[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(matricula: Matricula): Observable<string> {
+    return this.http.post<string>(this.API + '/save', matricula, { responseType: 'text' as 'json' });
+  }
+
+  update(matricula: Matricula): Observable<string> {
+    return this.http.put<string>(this.API + '/update', matricula, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<Matricula> {
+    return this.http.get<Matricula>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/pagamento.service.ts
+++ b/frontend/src/app/services/pagamento.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Pagamento } from '../models/pagamento';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PagamentoService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/pagamentos';
+
+  findAll(): Observable<Pagamento[]> {
+    return this.http.get<Pagamento[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(pagamento: Pagamento): Observable<string> {
+    return this.http.post<string>(this.API + '/save', pagamento, { responseType: 'text' as 'json' });
+  }
+
+  update(pagamento: Pagamento): Observable<string> {
+    return this.http.put<string>(this.API + '/update', pagamento, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<Pagamento> {
+    return this.http.get<Pagamento>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/parcela.service.ts
+++ b/frontend/src/app/services/parcela.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Parcela } from '../models/parcela';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ParcelaService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/parcelas';
+
+  findAll(): Observable<Parcela[]> {
+    return this.http.get<Parcela[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(parcela: Parcela): Observable<string> {
+    return this.http.post<string>(this.API + '/save', parcela, { responseType: 'text' as 'json' });
+  }
+
+  update(parcela: Parcela): Observable<string> {
+    return this.http.put<string>(this.API + '/update', parcela, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<Parcela> {
+    return this.http.get<Parcela>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/plano-pagamento.service.ts
+++ b/frontend/src/app/services/plano-pagamento.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { PlanoPagamento } from '../models/plano-pagamento';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PlanoPagamentoService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/planos-pagamento';
+
+  findAll(): Observable<PlanoPagamento[]> {
+    return this.http.get<PlanoPagamento[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(plano: PlanoPagamento): Observable<string> {
+    return this.http.post<string>(this.API + '/save', plano, { responseType: 'text' as 'json' });
+  }
+
+  update(plano: PlanoPagamento): Observable<string> {
+    return this.http.put<string>(this.API + '/update', plano, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<PlanoPagamento> {
+    return this.http.get<PlanoPagamento>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/receita.service.ts
+++ b/frontend/src/app/services/receita.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Receita } from '../models/receita';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReceitaService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/receitas';
+
+  findAll(): Observable<Receita[]> {
+    return this.http.get<Receita[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(receita: Receita): Observable<string> {
+    return this.http.post<string>(this.API + '/save', receita, { responseType: 'text' as 'json' });
+  }
+
+  update(receita: Receita): Observable<string> {
+    return this.http.put<string>(this.API + '/update', receita, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<Receita> {
+    return this.http.get<Receita>(this.API + '/findById/' + id);
+  }
+}


### PR DESCRIPTION
## Summary
- include missing TypeScript models for financial entities
- add Angular services to consume financial endpoints

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d5e5e2908320970502c7b15e3baf