### PR TITLE
Add Planos details component

### DIFF
--- a/frontend/src/app/components/financeiro/planos/planosdetails.component.html
+++ b/frontend/src/app/components/financeiro/planos/planosdetails.component.html
@@ -1,0 +1,52 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="card">
+      <div class="card-body">
+        <div class="col-lg-12">
+          <div class="card">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-4">
+                <h5 class="card-title mb-0">Cadastro de Planos</h5>
+              </div>
+              <div class="row mb-3">
+                <div class="col-md-6 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="text" id="descricao" class="form-control" [(ngModel)]="plano.descricao" />
+                    <label mdbLabel class="form-label" for="descricao">Descrição</label>
+                  </mdb-form-control>
+                </div>
+                <div class="col-md-6 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="number" id="parcelas" class="form-control" [(ngModel)]="plano.numeroParcelas" />
+                    <label mdbLabel class="form-label" for="parcelas">Número de Parcelas</label>
+                  </mdb-form-control>
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col-md-6 mb-3">
+                  <mdb-form-control>
+                    <select mdbInput class="form-select" [(ngModel)]="plano.periodicidade" [ngModelOptions]="{standalone: true}">
+                      <option *ngFor="let p of periodicidades" [value]="p">{{ p }}</option>
+                    </select>
+                    <label mdbLabel class="form-label" for="periodicidade">Periodicidade</label>
+                  </mdb-form-control>
+                </div>
+                <div class="col-md-6 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="number" id="valorTotal" class="form-control" [(ngModel)]="plano.valorTotal" />
+                    <label mdbLabel class="form-label" for="valorTotal">Valor Total</label>
+                  </mdb-form-control>
+                </div>
+              </div>
+              <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-3">
+                <button type="button" class="btn btn-warning btn-rounded" mdbRipple (click)="save()">
+                  <i class="fas fa-save me-2"></i>Salvar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/financeiro/planos/planosdetails.component.ts
+++ b/frontend/src/app/components/financeiro/planos/planosdetails.component.ts
@@ -1,0 +1,67 @@
+import { Component, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
+import { MdbRippleModule } from 'mdb-angular-ui-kit/ripple';
+import { ActivatedRoute, Router } from '@angular/router';
+import Swal from 'sweetalert2';
+import { PlanoPagamento } from '../../../models/plano-pagamento';
+import { PlanoPagamentoService } from '../../../services/plano-pagamento.service';
+
+@Component({
+  selector: 'app-planosdetails',
+  standalone: true,
+  imports: [CommonModule, MdbFormsModule, MdbRippleModule, FormsModule],
+  templateUrl: './planosdetails.component.html'
+})
+export class PlanosdetailsComponent {
+
+  plano: PlanoPagamento = new PlanoPagamento('', 0, '', 0);
+  periodicidades: string[] = ['Mensal', 'Bimestral', 'Trimestral', 'Semestral', 'Anual'];
+  router = inject(ActivatedRoute);
+  router2 = inject(Router);
+  planosService = inject(PlanoPagamentoService);
+
+  constructor() {
+    const id = this.router.snapshot.params['id'];
+    if (id > 0) {
+      this.findById(id);
+    }
+  }
+
+  findById(id: number) {
+    this.planosService.findById(id).subscribe({
+      next: ret => { this.plano = ret; },
+      error: () => {
+        Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+      }
+    });
+  }
+
+  save() {
+    if (this.plano.id) {
+      this.planosService.update(this.plano).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Plano editado com sucesso!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/planos']);
+        },
+        error: () => {
+          Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+        }
+      });
+    } else {
+      const planoParaSalvar = { ...this.plano } as PlanoPagamento;
+      delete planoParaSalvar.id;
+      this.planosService.save(planoParaSalvar).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Plano cadastrado com sucesso!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/planos']);
+        },
+        error: erro => {
+          console.error('Erro completo:', erro);
+          Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' });
+        }
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add PlanosdetailsComponent to manage payment plan form
- create matching HTML template with fields for description, number of installments, periodicity and total value

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dbc0ebd083209c8491c22f69981f