### PR TITLE
Add manual entry form for receitas/despesas

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -22,6 +22,7 @@ import { PlanoslistComponent } from './components/financeiro/planos/planoslist.c
 import { ParcelaslistComponent } from './components/financeiro/parcelas/parcelaslist.component';
 import { PagamentoslistComponent } from './components/financeiro/pagamentos/pagamentoslist.component';
 import { ReceitasDespesasComponent } from './components/financeiro/receitas-despesas/receitas-despesas.component';
+import { ReceitasDespesasdetailsComponent } from './components/financeiro/receitas-despesas/receitas-despesasdetails.component';
 import { CaixalistComponent } from './components/financeiro/caixa/caixalist.component';
 import { DescontoslistComponent } from './components/financeiro/descontos/descontoslist.component';
 
@@ -59,6 +60,7 @@ export const routes: Routes = [
     {path: "parcelas", component: ParcelaslistComponent},
     {path: "pagamentos", component: PagamentoslistComponent},
     {path: "receitas-despesas", component: ReceitasDespesasComponent},
+    {path: "receitas-despesas/new", component: ReceitasDespesasdetailsComponent},
     {path: "caixa", component: CaixalistComponent},
     {path: "descontos", component: DescontoslistComponent}
 

--- a/frontend/src/app/components/financeiro/receitas-despesas/receitas-despesas.component.html
+++ b/frontend/src/app/components/financeiro/receitas-despesas/receitas-despesas.component.html
@@ -14,7 +14,7 @@
           <div class="tab-content">
             <div class="tab-pane fade show active" id="receitas" role="tabpanel">
               <div class="d-flex justify-content-end mb-3">
-                <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple>
+                <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/receitas-despesas/new">
                   <i class="fas fa-plus me-1"></i> Nova Receita
                 </button>
               </div>
@@ -31,7 +31,7 @@
             </div>
             <div class="tab-pane fade" id="despesas" role="tabpanel">
               <div class="d-flex justify-content-end mb-3">
-                <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple>
+                <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/receitas-despesas/new">
                   <i class="fas fa-plus me-1"></i> Nova Despesa
                 </button>
               </div>

--- a/frontend/src/app/components/financeiro/receitas-despesas/receitas-despesasdetails.component.html
+++ b/frontend/src/app/components/financeiro/receitas-despesas/receitas-despesasdetails.component.html
@@ -1,0 +1,61 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="card">
+      <div class="card-body">
+        <div class="col-lg-12">
+          <div class="card">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-4">
+                <h5 class="card-title mb-0">Registrar Receita/Despesa</h5>
+              </div>
+              <div class="row mb-3">
+                <div class="col-md-4 mb-3">
+                  <mdb-form-control>
+                    <select mdbInput class="form-select" [(ngModel)]="tipo" [ngModelOptions]="{standalone: true}">
+                      <option value="RECEITA">Receita</option>
+                      <option value="DESPESA">Despesa</option>
+                    </select>
+                    <label mdbLabel class="form-label">Tipo</label>
+                  </mdb-form-control>
+                </div>
+                <div class="col-md-8 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="text" class="form-control" [(ngModel)]="lancamento.descricao" />
+                    <label mdbLabel class="form-label">Descrição</label>
+                  </mdb-form-control>
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col-md-4 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="text" class="form-control" [(ngModel)]="lancamento.categoria" />
+                    <label mdbLabel class="form-label">Categoria</label>
+                  </mdb-form-control>
+                </div>
+                <div class="col-md-4 mb-3">
+                  <mat-form-field appearance="fill" style="width: 100%;">
+                    <mat-label>Data</mat-label>
+                    <input matInput [matDatepicker]="picker" [(ngModel)]="lancamento.data">
+                    <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+                    <mat-datepicker #picker></mat-datepicker>
+                  </mat-form-field>
+                </div>
+                <div class="col-md-4 mb-3">
+                  <mdb-form-control>
+                    <input mdbInput type="number" step="0.01" class="form-control" [(ngModel)]="lancamento.valor" />
+                    <label mdbLabel class="form-label">Valor</label>
+                  </mdb-form-control>
+                </div>
+              </div>
+              <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-3">
+                <button type="button" class="btn btn-warning btn-rounded" mdbRipple (click)="save()">
+                  <i class="fas fa-save me-2"></i>Salvar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/financeiro/receitas-despesas/receitas-despesasdetails.component.ts
+++ b/frontend/src/app/components/financeiro/receitas-despesas/receitas-despesasdetails.component.ts
@@ -1,0 +1,58 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
+import { MdbRippleModule } from 'mdb-angular-ui-kit/ripple';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { Router } from '@angular/router';
+import Swal from 'sweetalert2';
+import { Receita } from '../../../models/receita';
+import { Despesa } from '../../../models/despesa';
+import { ReceitaService } from '../../../services/receita.service';
+import { DespesaService } from '../../../services/despesa.service';
+
+interface LancamentoForm {
+  descricao: string;
+  categoria: string;
+  data: Date | null;
+  valor: number;
+}
+
+@Component({
+  selector: 'app-receitas-despesasdetails',
+  standalone: true,
+  imports: [CommonModule, MdbFormsModule, MdbRippleModule, FormsModule, MatDatepickerModule, MatFormFieldModule, MatInputModule],
+  templateUrl: './receitas-despesasdetails.component.html'
+})
+export class ReceitasDespesasdetailsComponent {
+  tipo: 'RECEITA' | 'DESPESA' = 'RECEITA';
+  lancamento: LancamentoForm = { descricao: '', categoria: '', data: null, valor: 0 };
+
+  receitaService = inject(ReceitaService);
+  despesaService = inject(DespesaService);
+  router = inject(Router);
+
+  save() {
+    if (this.tipo === 'RECEITA') {
+      const receita = new Receita(this.lancamento.descricao, this.lancamento.valor, this.lancamento.data, this.lancamento.categoria);
+      this.receitaService.save(receita).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Receita registrada com sucesso!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router.navigate(['admin/receitas-despesas']);
+        },
+        error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+      });
+    } else {
+      const despesa = new Despesa(this.lancamento.descricao, this.lancamento.valor, this.lancamento.data, this.lancamento.categoria);
+      this.despesaService.save(despesa).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Despesa registrada com sucesso!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router.navigate(['admin/receitas-despesas']);
+        },
+        error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow creating manual financial entries
- link from list page to the new form
- wire up new route to the details component

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e1eec3b88320b481f5822572ce80