### PR TITLE
Fix frontend grids to match backend models

### DIFF
--- a/frontend/src/app/components/financeiro/caixa/caixalist.component.ts
+++ b/frontend/src/app/components/financeiro/caixa/caixalist.component.ts
@@ -39,11 +39,15 @@ export class CaixalistComponent {
   };
 
   colDefs: ColDef<LancamentoFinanceiro>[] = [
-    { field: 'data', headerName: 'Data', filter: 'agDateColumnFilter', floatingFilter: true, valueFormatter: p => p.value ? new Date(p.value).toLocaleDateString('pt-BR') : '' },
-    { field: 'descricao', headerName: 'Descrição', filter: 'agTextColumnFilter', floatingFilter: true },
-    { field: 'tipo', headerName: 'Tipo', filter: 'agTextColumnFilter', floatingFilter: true },
-    { field: 'valor', headerName: 'Valor', filter: 'agNumberColumnFilter', floatingFilter: true },
-    { field: 'saldo', headerName: 'Saldo Acumulado', filter: 'agNumberColumnFilter', floatingFilter: true }
+    {
+      field: 'data',
+      headerName: 'Data',
+      filter: 'agDateColumnFilter',
+      floatingFilter: true,
+      valueFormatter: p => p.value ? new Date(p.value).toLocaleDateString('pt-BR') : ''
+    },
+    { field: 'saldoDiario', headerName: 'Saldo Diário', filter: 'agNumberColumnFilter', floatingFilter: true },
+    { field: 'saldoMensal', headerName: 'Saldo Mensal', filter: 'agNumberColumnFilter', floatingFilter: true }
   ];
 
   defaultColDef: ColDef = {

--- a/frontend/src/app/components/financeiro/descontos/descontosdetails.component.html
+++ b/frontend/src/app/components/financeiro/descontos/descontosdetails.component.html
@@ -11,31 +11,14 @@
               <div class="row mb-3">
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" class="form-control" [(ngModel)]="desconto.descricao" />
-                    <label mdbLabel class="form-label">Descrição</label>
-                  </mdb-form-control>
-                </div>
-                <div class="col-md-6 mb-3">
-                  <mdb-form-control>
-                    <select mdbInput class="form-select" [(ngModel)]="desconto.tipo" [ngModelOptions]="{standalone: true}">
-                      <option value="VALOR">Valor Fixo</option>
-                      <option value="PERCENTUAL">Percentual</option>
-                    </select>
-                    <label mdbLabel class="form-label">Tipo</label>
-                  </mdb-form-control>
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col-md-6 mb-3">
-                  <mdb-form-control>
                     <input mdbInput type="number" step="0.01" class="form-control" [(ngModel)]="desconto.valor" />
                     <label mdbLabel class="form-label">Valor</label>
                   </mdb-form-control>
                 </div>
                 <div class="col-md-6 mb-3">
                   <mdb-form-control>
-                    <input mdbInput type="text" class="form-control" [(ngModel)]="desconto.criterio" />
-                    <label mdbLabel class="form-label">Critério</label>
+                    <input mdbInput type="text" class="form-control" [(ngModel)]="desconto.motivo" />
+                    <label mdbLabel class="form-label">Motivo</label>
                   </mdb-form-control>
                 </div>
               </div>

--- a/frontend/src/app/components/financeiro/descontos/descontosdetails.component.ts
+++ b/frontend/src/app/components/financeiro/descontos/descontosdetails.component.ts
@@ -9,10 +9,8 @@ import { DescontoService } from '../../../services/desconto.service';
 
 interface DescontoForm {
   id?: number;
-  descricao: string;
-  tipo: string;
   valor: number;
-  criterio: string;
+  motivo: string;
 }
 
 @Component({
@@ -22,7 +20,7 @@ interface DescontoForm {
   templateUrl: './descontosdetails.component.html'
 })
 export class DescontosdetailsComponent {
-  desconto: DescontoForm = { descricao: '', tipo: '', valor: 0, criterio: '' };
+  desconto: DescontoForm = { valor: 0, motivo: '' };
   router = inject(ActivatedRoute);
   router2 = inject(Router);
   descontoService = inject(DescontoService);

--- a/frontend/src/app/components/financeiro/descontos/descontoslist.component.ts
+++ b/frontend/src/app/components/financeiro/descontos/descontoslist.component.ts
@@ -40,9 +40,8 @@ export class DescontoslistComponent {
   };
 
   colDefs: ColDef<Desconto>[] = [
-    { field: 'descricao', headerName: 'Descrição', filter: 'agTextColumnFilter', floatingFilter: true },
-    { field: 'valor', headerName: 'Valor/Percentual', filter: 'agNumberColumnFilter', floatingFilter: true },
-    { field: 'criterio', headerName: 'Critério de Aplicação', filter: 'agTextColumnFilter', floatingFilter: true },
+    { field: 'valor', headerName: 'Valor', filter: 'agNumberColumnFilter', floatingFilter: true },
+    { field: 'motivo', headerName: 'Motivo', filter: 'agTextColumnFilter', floatingFilter: true },
     {
       headerName: 'Ações',
       cellRenderer: (params: any) => {
@@ -132,9 +131,8 @@ export class DescontoslistComponent {
       Swal.fire({
         title: 'Desconto',
         html: `
-          <p><strong>Descrição:</strong> ${desconto.descricao}</p>
           <p><strong>Valor:</strong> ${desconto.valor}</p>
-          <p><strong>Critério:</strong> ${desconto.criterio}</p>
+          <p><strong>Motivo:</strong> ${desconto.motivo}</p>
         `,
         icon: 'info'
       });

--- a/frontend/src/app/components/financeiro/pagamentos/pagamentoslist.component.ts
+++ b/frontend/src/app/components/financeiro/pagamentos/pagamentoslist.component.ts
@@ -44,7 +44,6 @@ export class PagamentoslistComponent {
     { field: 'dataPagamento', headerName: 'Data do Pagamento', filter: 'agDateColumnFilter', floatingFilter: true, valueFormatter: p => p.value ? new Date(p.value).toLocaleDateString('pt-BR') : '' },
     { field: 'valorPago', headerName: 'Valor Pago', filter: 'agNumberColumnFilter', floatingFilter: true },
     { field: 'formaPagamento', headerName: 'Forma de Pagamento', filter: 'agTextColumnFilter', floatingFilter: true },
-    { field: 'desconto.valor', headerName: 'Desconto Aplicado', valueGetter: p => p.data.desconto ? p.data.desconto.valor : '', filter: false },
     {
       headerName: 'Ações',
       cellRenderer: (params: any) => {

--- a/frontend/src/app/components/matriculas/matriculaslist/matriculaslist.component.ts
+++ b/frontend/src/app/components/matriculas/matriculaslist/matriculaslist.component.ts
@@ -43,7 +43,6 @@ export class MatriculaslistComponent {
     { field: 'aluno.nome', headerName: 'Aluno', valueGetter: params => params.data.aluno?.nome, filter: 'agTextColumnFilter', floatingFilter: true },
     { field: 'turma.nome', headerName: 'Turma', valueGetter: params => params.data.turma?.nome, filter: 'agTextColumnFilter', floatingFilter: true },
     { field: 'planoPagamento.descricao', headerName: 'Plano de Pagamento', valueGetter: params => params.data.planoPagamento?.descricao, filter: 'agTextColumnFilter', floatingFilter: true },
-    { field: 'anoSemestre', headerName: 'Ano/Semestre', filter: 'agTextColumnFilter', floatingFilter: true },
     {
       headerName: 'Ações',
       cellRenderer: (params: any) => {


### PR DESCRIPTION
## Summary
- update cash flow grid columns
- align discount forms and lists with the backend fields
- drop unused discount column from payments list
- remove missing `anoSemestre` from matriculas list

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e86712a88320918aecce332a1db1