### PR TITLE
Fix valueGetter null checks

### DIFF
--- a/frontend/src/app/components/financeiro/pagamentos/pagamentoslist.component.ts
+++ b/frontend/src/app/components/financeiro/pagamentos/pagamentoslist.component.ts
@@ -40,7 +40,7 @@ export class PagamentoslistComponent {
   };
 
   colDefs: ColDef<Pagamento>[] = [
-    { field: 'parcela.numero', headerName: 'Parcela', valueGetter: p => p.data.parcela?.numero, filter: 'agNumberColumnFilter', floatingFilter: true },
+    { field: 'parcela.numero', headerName: 'Parcela', valueGetter: params => params.data?.parcela?.numero, filter: 'agNumberColumnFilter', floatingFilter: true },
     { field: 'dataPagamento', headerName: 'Data do Pagamento', filter: 'agDateColumnFilter', floatingFilter: true, valueFormatter: p => p.value ? new Date(p.value).toLocaleDateString('pt-BR') : '' },
     { field: 'valorPago', headerName: 'Valor Pago', filter: 'agNumberColumnFilter', floatingFilter: true },
     { field: 'formaPagamento', headerName: 'Forma de Pagamento', filter: 'agTextColumnFilter', floatingFilter: true },

--- a/frontend/src/app/components/financeiro/parcelas/parcelaslist.component.ts
+++ b/frontend/src/app/components/financeiro/parcelas/parcelaslist.component.ts
@@ -40,7 +40,7 @@ export class ParcelaslistComponent {
   };
 
   colDefs: ColDef<Parcela>[] = [
-    { field: 'matricula.aluno.nome', headerName: 'Matrícula', valueGetter: params => `${params.data.matricula?.aluno?.nome}/${params.data.matricula?.turma?.nome}`, filter: 'agTextColumnFilter', floatingFilter: true },
+    { field: 'matricula.aluno.nome', headerName: 'Matrícula', valueGetter: params => `${params.data?.matricula?.aluno?.nome}/${params.data?.matricula?.turma?.nome}`, filter: 'agTextColumnFilter', floatingFilter: true },
     { field: 'numero', headerName: 'Número da Parcela', filter: 'agNumberColumnFilter', floatingFilter: true },
     { field: 'valorOriginal', headerName: 'Valor Original', filter: 'agNumberColumnFilter', floatingFilter: true },
     { field: 'dataVencimento', headerName: 'Data de Vencimento', filter: 'agDateColumnFilter', floatingFilter: true, valueFormatter: p => p.value ? new Date(p.value).toLocaleDateString('pt-BR') : '' },

--- a/frontend/src/app/components/matriculas/matriculaslist/matriculaslist.component.ts
+++ b/frontend/src/app/components/matriculas/matriculaslist/matriculaslist.component.ts
@@ -40,9 +40,9 @@ export class MatriculaslistComponent {
   };
 
   colDefs: ColDef<Matricula>[] = [
-    { field: 'aluno.nome', headerName: 'Aluno', valueGetter: params => params.data.aluno?.nome, filter: 'agTextColumnFilter', floatingFilter: true },
-    { field: 'turma.nome', headerName: 'Turma', valueGetter: params => params.data.turma?.nome, filter: 'agTextColumnFilter', floatingFilter: true },
-    { field: 'planoPagamento.descricao', headerName: 'Plano de Pagamento', valueGetter: params => params.data.planoPagamento?.descricao, filter: 'agTextColumnFilter', floatingFilter: true },
+    { field: 'aluno.nome', headerName: 'Aluno', valueGetter: params => params.data?.aluno?.nome, filter: 'agTextColumnFilter', floatingFilter: true },
+    { field: 'turma.nome', headerName: 'Turma', valueGetter: params => params.data?.turma?.nome, filter: 'agTextColumnFilter', floatingFilter: true },
+    { field: 'planoPagamento.descricao', headerName: 'Plano de Pagamento', valueGetter: params => params.data?.planoPagamento?.descricao, filter: 'agTextColumnFilter', floatingFilter: true },
     {
       headerName: 'Ações',
       cellRenderer: (params: any) => {


### PR DESCRIPTION
## Summary
- safely access row data in Parcelas, Pagamentos and Matrículas listings

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module '@angular/core')*
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e9af03788320947f31840887559c