### PR TITLE
Update README with Maven network note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Pré-requisitos:
 - Java 21
 - Maven
 
+> **Nota:** O Maven precisa acessar a internet para baixar dependências em um primeiro build.
+> Caso não haja conexão, utilize um espelho local do repositório ou um cache
+> pré-carregado. Em ambientes de CI, considere disponibilizar um repositório
+> Maven local para permitir builds offline.
+> Avalie também empacotar um cache do repositório Maven ou configurar o CI para fornecer essas dependências sem acesso à internet.
+
 Para executar:
 
 ```bash


### PR DESCRIPTION
## Summary
- document Maven's need for internet access or a local repo mirror
- mention possible Maven cache or CI adjustments for offline builds

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ea8ea52c8320a0c47003a6075c40