### PR TITLE
Fix finance module navigation

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -19,12 +19,16 @@ import { HomeComponent } from './components/home/home.component';
 import { RedirectComponent } from './components/layout/redirect/redirect.component';
 import { MatriculaslistComponent } from './components/matriculas/matriculaslist/matriculaslist.component';
 import { PlanoslistComponent } from './components/financeiro/planos/planoslist.component';
+import { PlanosdetailsComponent } from './components/financeiro/planos/planosdetails.component';
 import { ParcelaslistComponent } from './components/financeiro/parcelas/parcelaslist.component';
+import { ParcelasdetailsComponent } from './components/financeiro/parcelas/parcelasdetails/parcelasdetails.component';
 import { PagamentoslistComponent } from './components/financeiro/pagamentos/pagamentoslist.component';
+import { PagamentosdetailsComponent } from './components/financeiro/pagamentos/pagamentosdetails.component';
 import { ReceitasDespesasComponent } from './components/financeiro/receitas-despesas/receitas-despesas.component';
 import { ReceitasDespesasdetailsComponent } from './components/financeiro/receitas-despesas/receitas-despesasdetails.component';
 import { CaixalistComponent } from './components/financeiro/caixa/caixalist.component';
 import { DescontoslistComponent } from './components/financeiro/descontos/descontoslist.component';
+import { DescontosdetailsComponent } from './components/financeiro/descontos/descontosdetails.component';
 
 
 export const routes: Routes = [
@@ -57,12 +61,19 @@ export const routes: Routes = [
     {path: "permissao/edit/:id", component: PermissaoGrupoDetailsComponent},
     {path: "matriculas", component: MatriculaslistComponent},
     {path: "planos", component: PlanoslistComponent},
+    {path: "planos/new", component: PlanosdetailsComponent},
+    {path: "planos/edit/:id", component: PlanosdetailsComponent},
     {path: "parcelas", component: ParcelaslistComponent},
+    {path: "parcelas/edit/:id", component: ParcelasdetailsComponent},
     {path: "pagamentos", component: PagamentoslistComponent},
+    {path: "pagamentos/new", component: PagamentosdetailsComponent},
+    {path: "pagamentos/edit/:id", component: PagamentosdetailsComponent},
     {path: "receitas-despesas", component: ReceitasDespesasComponent},
     {path: "receitas-despesas/new", component: ReceitasDespesasdetailsComponent},
     {path: "caixa", component: CaixalistComponent},
-    {path: "descontos", component: DescontoslistComponent}
+    {path: "descontos", component: DescontoslistComponent},
+    {path: "descontos/new", component: DescontosdetailsComponent},
+    {path: "descontos/edit/:id", component: DescontosdetailsComponent}
 
   ]},
   { path: '**', redirectTo: '' }

--- a/frontend/src/app/components/financeiro/descontos/descontoslist.component.html
+++ b/frontend/src/app/components/financeiro/descontos/descontoslist.component.html
@@ -5,7 +5,7 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center mb-4">
             <h5 class="card-title mb-0">Descontos</h5>
-            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple>
+            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/descontos/new">
               <i class="fas fa-plus me-1"></i> Novo Desconto
             </button>
           </div>

--- a/frontend/src/app/components/financeiro/descontos/descontoslist.component.ts
+++ b/frontend/src/app/components/financeiro/descontos/descontoslist.component.ts
@@ -94,7 +94,7 @@ export class DescontoslistComponent {
       const action = button.getAttribute('data-action');
       const id = button.getAttribute('data-id');
       if (action === 'edit') {
-        // editar desconto
+        this.router.navigate(['admin/descontos/edit', id]);
       } else if (action === 'view') {
         this.viewById(Number(id));
       } else if (action === 'delete') {

--- a/frontend/src/app/components/financeiro/pagamentos/pagamentoslist.component.html
+++ b/frontend/src/app/components/financeiro/pagamentos/pagamentoslist.component.html
@@ -5,7 +5,7 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center mb-4">
             <h5 class="card-title mb-0">Pagamentos</h5>
-            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple>
+            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/pagamentos/new">
               <i class="fas fa-plus me-1"></i> Novo Pagamento
             </button>
           </div>

--- a/frontend/src/app/components/financeiro/parcelas/parcelaslist.component.ts
+++ b/frontend/src/app/components/financeiro/parcelas/parcelaslist.component.ts
@@ -95,7 +95,7 @@ export class ParcelaslistComponent {
       const action = button.getAttribute('data-action');
       const id = button.getAttribute('data-id');
       if (action === 'edit') {
-        // editar pagamento
+        this.router.navigate(['admin/parcelas/edit', id]);
       } else if (action === 'view') {
         this.viewById(Number(id));
       } else if (action === 'quit') {

--- a/frontend/src/app/components/financeiro/planos/planoslist.component.html
+++ b/frontend/src/app/components/financeiro/planos/planoslist.component.html
@@ -5,7 +5,7 @@
         <div class="card-body">
           <div class="d-flex justify-content-between align-items-center mb-4">
             <h5 class="card-title mb-0">Planos de Pagamento</h5>
-            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple>
+            <button *ngIf="canAdd" type="button" class="btn btn-warning btn-rounded" mdbRipple routerLink="/admin/planos/new">
               <i class="fas fa-plus me-1"></i> Novo Plano
             </button>
           </div>

--- a/frontend/src/app/components/financeiro/planos/planoslist.component.ts
+++ b/frontend/src/app/components/financeiro/planos/planoslist.component.ts
@@ -96,7 +96,7 @@ export class PlanoslistComponent {
       const action = button.getAttribute('data-action');
       const id = button.getAttribute('data-id');
       if (action === 'edit') {
-        // rota de edição ainda não criada
+        this.router.navigate(['admin/planos/edit', id]);
       } else if (action === 'view') {
         this.viewById(Number(id));
       } else if (action === 'delete') {


### PR DESCRIPTION
## Summary
- wire up new-plan button and edit action in Planos list
- add links for creating discounts, payments, and editing parcels
- define routes for financial forms

## Testing
- `npm install`
- `npm test --silent` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_686816b6f7f08320977d5c9a82873d52