### PR TITLE
Add enrollment shortcut

### DIFF
--- a/frontend/src/app/components/alunos/alunoslist/alunoslist.component.ts
+++ b/frontend/src/app/components/alunos/alunoslist/alunoslist.component.ts
@@ -72,10 +72,15 @@ export class AlunoslistComponent {
           `<button type="button" class="btn btn-danger btn-rounded btn-sm btn-icon" data-action="delete" data-id="${aluno.id}">
             <i class="fas fa-trash-alt"></i>
           </button>` : '';
+        const matriculaBtn = this.canMatricular ?
+          `<button type="button" class="btn btn-success btn-rounded btn-sm btn-icon" data-action="matricular" data-id="${aluno.id}">
+            <i class="fas fa-user-plus"></i>
+          </button>` : '';
         return `
           <button type="button" class="btn btn-info btn-rounded btn-sm btn-icon" data-action="view" data-id="${aluno.id}">
             <i class="fas fa-eye"></i>
           </button>
+          ${matriculaBtn}
           ${editBtn}
           ${delBtn}
         `;
@@ -110,6 +115,10 @@ export class AlunoslistComponent {
     return this.usuariosService.hasPermission('/alunos', 'DELETE');
   }
 
+  get canMatricular() {
+    return this.usuariosService.hasPermission('/matriculas', 'POST');
+  }
+
   constructor() {
     this.findAll();
   }
@@ -126,6 +135,8 @@ export class AlunoslistComponent {
         this.viewById(Number(id));
       } else if (action === 'delete') {
         this.deleteById(Number(id));
+      } else if (action === 'matricular') {
+        this.router.navigate(['/admin/matriculas/new'], { queryParams: { alunoId: id } });
       }
     }
   };

--- a/frontend/src/app/components/matriculas/matriculasdetails/matriculasdetails.component.ts
+++ b/frontend/src/app/components/matriculas/matriculasdetails/matriculasdetails.component.ts
@@ -64,7 +64,16 @@ export class MatriculasdetailsComponent implements OnInit {
 
   loadAlunos() {
     this.alunosService.findAll().subscribe({
-      next: lista => this.alunos = lista,
+      next: lista => {
+        this.alunos = lista;
+        const alunoId = this.router.snapshot.queryParamMap.get('alunoId');
+        if (alunoId) {
+          const alunoSel = lista.find(a => a.id === Number(alunoId));
+          if (alunoSel) {
+            this.matricula.aluno = alunoSel;
+          }
+        }
+      },
       error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
     });
   }


### PR DESCRIPTION
## Summary
- add a new "matricular" button to each student row
- allow navigating to the enrollment form with student preselected
- handle `alunoId` query param in matricula details component

## Testing
- `npm test --silent --no-progress` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1a073208320a3064496651b3b1b