### PR TITLE
Add professor REST layer

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/ProfessorController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/ProfessorController.java
@@ -1,0 +1,69 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.sentinel.backend.entity.Professor;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.service.ProfessorService;
+
+@RestController
+@RequestMapping("/professores")
+@CrossOrigin("*")
+@Slf4j
+public class ProfessorController {
+
+    @Autowired
+    private ProfessorService ps;
+
+    @GetMapping("/findAll")
+    public Iterable<Professor> listar() {
+        return ps.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return ps.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody Professor professor) {
+        return ps.cadastrarAlterar(professor, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody Professor professor) {
+        return ps.cadastrarAlterar(professor, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<Professor> findById(@PathVariable long id) {
+        log.info("Finding professor with id {}", id);
+        try {
+            Optional<Professor> prof = ps.findById(id);
+            if (prof.isPresent()) {
+                log.info("Professor {} found", id);
+                return new ResponseEntity<>(prof.get(), HttpStatus.OK);
+            }
+            log.warn("Professor {} not found", id);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            log.error("Error retrieving professor {}", id, e);
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/ProfessorRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/ProfessorRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.Professor;
+
+public interface ProfessorRepository extends JpaRepository<Professor, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/service/ProfessorService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/ProfessorService.java
@@ -1,0 +1,79 @@
+package com.sentinel.backend.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.sentinel.backend.entity.PermissaoGrupo;
+import com.sentinel.backend.entity.Professor;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.entity.Usuario;
+import com.sentinel.backend.repository.PermissaoGrupoRepository;
+import com.sentinel.backend.repository.ProfessorRepository;
+
+@Service
+public class ProfessorService {
+
+    @Autowired
+    private ProfessorRepository pr;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    @Autowired
+    private UsuarioService usuarioService;
+
+    @Autowired
+    private PermissaoGrupoRepository permissaoGrupoRepository;
+
+    public Iterable<Professor> listar() {
+        return pr.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(Professor professor, String acao) {
+        if (professor.getFuncionario() == null) {
+            rm.setMensagem("O funcionário é obrigatório!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+        Usuario usuario = professor.getUsuario();
+        if (usuario == null && acao.equalsIgnoreCase("cadastrar")) {
+            usuario = new Usuario();
+            usuario.setNome(professor.getFuncionario().getNome());
+            usuario.setEmail(professor.getFuncionario().getEmail());
+            usuario.setSenha("123456");
+            PermissaoGrupo pg = permissaoGrupoRepository.findAll().stream()
+                    .filter(p -> "ADMIN".equalsIgnoreCase(p.getNome()))
+                    .findFirst().orElse(null);
+            usuario.setPermissaoGrupo(pg);
+            ResponseEntity<?> resp = usuarioService.cadastrarAlterar(usuario, "cadastrar");
+            if (resp.getStatusCode() != HttpStatus.CREATED && resp.getStatusCode() != HttpStatus.OK) {
+                return resp;
+            }
+            professor.setUsuario((Usuario) resp.getBody());
+        } else if (usuario != null) {
+            usuarioService.cadastrarAlterar(usuario, acao);
+        }
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            return new ResponseEntity<>(pr.save(professor), HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(pr.save(professor), HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!pr.existsById(id)) {
+            rm.setMensagem("Professor não encontrado!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+        pr.deleteById(id);
+        rm.setMensagem("Professor excluído com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public Optional<Professor> findById(long id) {
+        return pr.findById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- create `ProfessorRepository` to manage professor entities
- implement `ProfessorService` with automatic user creation
- expose `/professores` endpoints in `ProfessorController`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM because network is unreachable)*
- `./mvnw -q -Dmaven.test.skip=true package` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bc08c8ab48320a79cd719eee74373