### PR TITLE
Add Professor service and model

### DIFF
--- a/frontend/src/app/models/professor.ts
+++ b/frontend/src/app/models/professor.ts
@@ -1,0 +1,26 @@
+import { Funcionario } from './funcionario';
+import { Usuario } from './usuario';
+import { Turma } from './turmas';
+import { Disciplina } from './disciplina';
+
+export class Professor {
+  id?: number;
+  funcionario: Funcionario | null;
+  usuario: Usuario | null;
+  turmas: Turma[];
+  disciplinas: Disciplina[];
+
+  constructor(
+    funcionario: Funcionario | null,
+    usuario: Usuario | null,
+    turmas: Turma[] = [],
+    disciplinas: Disciplina[] = [],
+    id?: number
+  ) {
+    this.id = id;
+    this.funcionario = funcionario;
+    this.usuario = usuario;
+    this.turmas = turmas;
+    this.disciplinas = disciplinas;
+  }
+}

--- a/frontend/src/app/services/professor.service.ts
+++ b/frontend/src/app/services/professor.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Professor } from '../models/professor';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProfessorService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/professores';
+
+  findAll(): Observable<Professor[]> {
+    return this.http.get<Professor[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(professor: Professor): Observable<string> {
+    return this.http.post<string>(this.API + '/save', professor, { responseType: 'text' as 'json' });
+  }
+
+  update(professor: Professor): Observable<string> {
+    return this.http.put<string>(this.API + '/update', professor, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<Professor> {
+    return this.http.get<Professor>(this.API + '/findById/' + id);
+  }
+}


### PR DESCRIPTION
## Summary
- add `Professor` model mirroring backend entity fields
- create `ProfessorService` with CRUD endpoints

## Testing
- `npm install`
- `npm test` *(fails: No Chrome binary available)*

------
https://chatgpt.com/codex/tasks/task_e_686bc6f2c6e88320b40ff80916415836