### PR TITLE
Implement diaries for class and board

### DIFF
--- a/backend/src/main/java/com/sentinel/backend/controller/DiarioBordoController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/DiarioBordoController.java
@@ -1,0 +1,69 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import com.sentinel.backend.entity.DiarioBordo;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.service.DiarioBordoService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/diarios-bordo")
+@CrossOrigin("*")
+@Slf4j
+public class DiarioBordoController {
+
+    @Autowired
+    private DiarioBordoService service;
+
+    @GetMapping("/findAll")
+    public Iterable<DiarioBordo> listar() {
+        return service.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return service.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody DiarioBordo diario) {
+        return service.cadastrarAlterar(diario, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody DiarioBordo diario) {
+        return service.cadastrarAlterar(diario, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<DiarioBordo> findById(@PathVariable long id) {
+        log.info("Finding diario bordo with id {}", id);
+        try {
+            Optional<DiarioBordo> obj = service.findById(id);
+            if (obj.isPresent()) {
+                log.info("Diario bordo {} found", id);
+                return new ResponseEntity<>(obj.get(), HttpStatus.OK);
+            }
+            log.warn("Diario bordo {} not found", id);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            log.error("Error retrieving diario bordo {}", id, e);
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/controller/DiarioClasseController.java
+++ b/backend/src/main/java/com/sentinel/backend/controller/DiarioClasseController.java
@@ -1,0 +1,69 @@
+package com.sentinel.backend.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+import com.sentinel.backend.entity.DiarioClasse;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.service.DiarioClasseService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/diarios-classe")
+@CrossOrigin("*")
+@Slf4j
+public class DiarioClasseController {
+
+    @Autowired
+    private DiarioClasseService service;
+
+    @GetMapping("/findAll")
+    public Iterable<DiarioClasse> listar() {
+        return service.listar();
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<RespostaModelo> remover(@PathVariable long id) {
+        return service.remover(id);
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> alterar(@RequestBody DiarioClasse diario) {
+        return service.cadastrarAlterar(diario, "alterar");
+    }
+
+    @PostMapping("/save")
+    public ResponseEntity<?> cadastrar(@RequestBody DiarioClasse diario) {
+        return service.cadastrarAlterar(diario, "cadastrar");
+    }
+
+    @GetMapping("/findById/{id}")
+    public ResponseEntity<DiarioClasse> findById(@PathVariable long id) {
+        log.info("Finding diario classe with id {}", id);
+        try {
+            Optional<DiarioClasse> obj = service.findById(id);
+            if (obj.isPresent()) {
+                log.info("Diario classe {} found", id);
+                return new ResponseEntity<>(obj.get(), HttpStatus.OK);
+            }
+            log.warn("Diario classe {} not found", id);
+            return new ResponseEntity<>(null, HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            log.error("Error retrieving diario classe {}", id, e);
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/entity/DiarioBordo.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/DiarioBordo.java
@@ -1,0 +1,40 @@
+package com.sentinel.backend.entity;
+
+import java.util.Date;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "diarios_bordo")
+@Getter
+@Setter
+public class DiarioBordo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Date data;
+    private String anotacao;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "aluno_id")
+    private Aluno aluno;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "turma_id")
+    private Turma turma;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "professor_id")
+    private Professor professor;
+}

--- a/backend/src/main/java/com/sentinel/backend/entity/DiarioClasse.java
+++ b/backend/src/main/java/com/sentinel/backend/entity/DiarioClasse.java
@@ -1,0 +1,47 @@
+package com.sentinel.backend.entity;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "diarios_classe")
+@Getter
+@Setter
+public class DiarioClasse {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Date data;
+    private String tipo; // nota ou falta
+    private BigDecimal valor;
+    private String observacao;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "professor_id")
+    private Professor professor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "turma_id")
+    private Turma turma;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "disciplina_id")
+    private Disciplina disciplina;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "aluno_id")
+    private Aluno aluno;
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/DiarioBordoRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/DiarioBordoRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.DiarioBordo;
+
+public interface DiarioBordoRepository extends JpaRepository<DiarioBordo, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/repository/DiarioClasseRepository.java
+++ b/backend/src/main/java/com/sentinel/backend/repository/DiarioClasseRepository.java
@@ -1,0 +1,8 @@
+package com.sentinel.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sentinel.backend.entity.DiarioClasse;
+
+public interface DiarioClasseRepository extends JpaRepository<DiarioClasse, Long> {
+}

--- a/backend/src/main/java/com/sentinel/backend/service/DiarioBordoService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/DiarioBordoService.java
@@ -1,0 +1,53 @@
+package com.sentinel.backend.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.sentinel.backend.entity.DiarioBordo;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.repository.DiarioBordoRepository;
+
+@Service
+public class DiarioBordoService {
+
+    @Autowired
+    private DiarioBordoRepository repository;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    public Iterable<DiarioBordo> listar() {
+        return repository.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(DiarioBordo diario, String acao) {
+        if (diario.getAluno() == null || diario.getTurma() == null || diario.getProfessor() == null) {
+            rm.setMensagem("Aluno, Turma e Professor são obrigatórios!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+        DiarioBordo saved = repository.save(diario);
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            return new ResponseEntity<>(saved, HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(saved, HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!repository.existsById(id)) {
+            rm.setMensagem("Registro não encontrado!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+        repository.deleteById(id);
+        rm.setMensagem("Registro removido com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public Optional<DiarioBordo> findById(long id) {
+        return repository.findById(id);
+    }
+}

--- a/backend/src/main/java/com/sentinel/backend/service/DiarioClasseService.java
+++ b/backend/src/main/java/com/sentinel/backend/service/DiarioClasseService.java
@@ -1,0 +1,54 @@
+package com.sentinel.backend.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.sentinel.backend.entity.DiarioClasse;
+import com.sentinel.backend.entity.RespostaModelo;
+import com.sentinel.backend.repository.DiarioClasseRepository;
+
+@Service
+public class DiarioClasseService {
+
+    @Autowired
+    private DiarioClasseRepository repository;
+
+    @Autowired
+    private RespostaModelo rm;
+
+    public Iterable<DiarioClasse> listar() {
+        return repository.findAll();
+    }
+
+    public ResponseEntity<?> cadastrarAlterar(DiarioClasse diario, String acao) {
+        if (diario.getProfessor() == null || diario.getTurma() == null
+                || diario.getDisciplina() == null || diario.getAluno() == null) {
+            rm.setMensagem("Professor, Turma, Disciplina e Aluno são obrigatórios!");
+            return new ResponseEntity<>(rm, HttpStatus.BAD_REQUEST);
+        }
+        DiarioClasse saved = repository.save(diario);
+        if (acao.equalsIgnoreCase("cadastrar")) {
+            return new ResponseEntity<>(saved, HttpStatus.CREATED);
+        } else {
+            return new ResponseEntity<>(saved, HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<RespostaModelo> remover(long id) {
+        if (!repository.existsById(id)) {
+            rm.setMensagem("Registro não encontrado!");
+            return new ResponseEntity<>(rm, HttpStatus.NOT_FOUND);
+        }
+        repository.deleteById(id);
+        rm.setMensagem("Registro removido com sucesso!");
+        return new ResponseEntity<>(rm, HttpStatus.OK);
+    }
+
+    public Optional<DiarioClasse> findById(long id) {
+        return repository.findById(id);
+    }
+}

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -32,6 +32,10 @@ import { ReceitasDespesasdetailsComponent } from './components/financeiro/receit
 import { CaixalistComponent } from './components/financeiro/caixa/caixalist.component';
 import { DescontoslistComponent } from './components/financeiro/descontos/descontoslist.component';
 import { DescontosdetailsComponent } from './components/financeiro/descontos/descontosdetails.component';
+import { DiarioClasseListComponent } from './components/diario-classe/diario-classe-list/diario-classe-list.component';
+import { DiarioClasseFormComponent } from './components/diario-classe/diario-classe-form/diario-classe-form.component';
+import { DiarioBordoListComponent } from './components/diario-bordo/diario-bordo-list/diario-bordo-list.component';
+import { DiarioBordoFormComponent } from './components/diario-bordo/diario-bordo-form/diario-bordo-form.component';
 
 
 export const routes: Routes = [
@@ -79,7 +83,13 @@ export const routes: Routes = [
     {path: "caixa", component: CaixalistComponent},
     {path: "descontos", component: DescontoslistComponent},
     {path: "descontos/new", component: DescontosdetailsComponent},
-    {path: "descontos/edit/:id", component: DescontosdetailsComponent}
+    {path: "descontos/edit/:id", component: DescontosdetailsComponent},
+    {path: "diario-classe", component: DiarioClasseListComponent},
+    {path: "diario-classe/new", component: DiarioClasseFormComponent},
+    {path: "diario-classe/edit/:id", component: DiarioClasseFormComponent},
+    {path: "diario-bordo", component: DiarioBordoListComponent},
+    {path: "diario-bordo/new", component: DiarioBordoFormComponent},
+    {path: "diario-bordo/edit/:id", component: DiarioBordoFormComponent}
 
   ]},
   { path: '**', redirectTo: '' }

--- a/frontend/src/app/components/diario-bordo/diario-bordo-form/diario-bordo-form.component.html
+++ b/frontend/src/app/components/diario-bordo/diario-bordo-form/diario-bordo-form.component.html
@@ -1,0 +1,13 @@
+<div class="container mt-3">
+  <form (ngSubmit)="save()" #form="ngForm">
+    <div class="mb-3">
+      <label class="form-label">Data</label>
+      <input mdbInput type="date" [(ngModel)]="diario.data" name="data" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Anotação</label>
+      <textarea mdbInput [(ngModel)]="diario.anotacao" name="anotacao" class="form-control"></textarea>
+    </div>
+    <button mdbBtn type="submit" class="btn btn-primary">Salvar</button>
+  </form>
+</div>

--- a/frontend/src/app/components/diario-bordo/diario-bordo-form/diario-bordo-form.component.ts
+++ b/frontend/src/app/components/diario-bordo/diario-bordo-form/diario-bordo-form.component.ts
@@ -1,0 +1,58 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
+import { MdbRippleModule } from 'mdb-angular-ui-kit/ripple';
+import { ActivatedRoute, Router } from '@angular/router';
+import Swal from 'sweetalert2';
+import { DiarioBordoService } from '../../../services/diario-bordo.service';
+import { DiarioBordo } from '../../../models/diario-bordo';
+
+@Component({
+  selector: 'app-diario-bordo-form',
+  standalone: true,
+  imports: [CommonModule, MdbFormsModule, MdbRippleModule, FormsModule],
+  templateUrl: './diario-bordo-form.component.html'
+})
+export class DiarioBordoFormComponent {
+  diario: DiarioBordo = new DiarioBordo(null, '', null, null, null);
+  router = inject(ActivatedRoute);
+  router2 = inject(Router);
+  diarioService = inject(DiarioBordoService);
+
+  constructor() {
+    const id = this.router.snapshot.params['id'];
+    if (id) {
+      this.findById(id);
+    }
+  }
+
+  findById(id: number) {
+    this.diarioService.findById(id).subscribe({
+      next: d => this.diario = d,
+      error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+    });
+  }
+
+  save() {
+    if (this.diario.id) {
+      this.diarioService.update(this.diario).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Registro editado!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/diario-bordo']);
+        },
+        error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+      });
+    } else {
+      const obj = { ...this.diario };
+      delete obj.id;
+      this.diarioService.save(obj).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Registro cadastrado!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/diario-bordo']);
+        },
+        error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+      });
+    }
+  }
+}

--- a/frontend/src/app/components/diario-bordo/diario-bordo-list/diario-bordo-list.component.html
+++ b/frontend/src/app/components/diario-bordo/diario-bordo-list/diario-bordo-list.component.html
@@ -1,0 +1,10 @@
+<div class="container mt-3">
+  <ag-grid-angular
+    class="ag-theme-alpine"
+    [rowData]="rowData"
+    [columnDefs]="colDefs"
+    [defaultColDef]="defaultColDef"
+    [gridOptions]="gridOptions"
+    (gridReady)="onGridReady($event)">
+  </ag-grid-angular>
+</div>

--- a/frontend/src/app/components/diario-bordo/diario-bordo-list/diario-bordo-list.component.ts
+++ b/frontend/src/app/components/diario-bordo/diario-bordo-list/diario-bordo-list.component.ts
@@ -1,0 +1,51 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { AgGridModule } from 'ag-grid-angular';
+import { MdbRippleModule } from 'mdb-angular-ui-kit/ripple';
+import { ColDef, GridApi, GridOptions, GridReadyEvent } from 'ag-grid-community';
+import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
+import { DiarioBordo } from '../../../models/diario-bordo';
+import { DiarioBordoService } from '../../../services/diario-bordo.service';
+import Swal from 'sweetalert2';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+@Component({
+  selector: 'app-diario-bordo-list',
+  standalone: true,
+  imports: [CommonModule, AgGridModule, MdbRippleModule, RouterLink],
+  templateUrl: './diario-bordo-list.component.html'
+})
+export class DiarioBordoListComponent {
+  private gridApi!: GridApi<DiarioBordo>;
+  public gridOptions: GridOptions<DiarioBordo> = {
+    pagination: true,
+    paginationPageSize: 20,
+    domLayout: 'autoHeight'
+  };
+
+  colDefs: ColDef<DiarioBordo>[] = [
+    { field: 'data', headerName: 'Data', valueFormatter: p => p.value ? new Date(p.value).toLocaleDateString('pt-BR') : '' },
+    { field: 'anotacao', headerName: 'Anotação' }
+  ];
+
+  defaultColDef: ColDef = { sortable: true, filter: true, resizable: true, flex: 1 };
+
+  rowData: DiarioBordo[] = [];
+  diarioService = inject(DiarioBordoService);
+
+  constructor() { this.findAll(); }
+
+  findAll() {
+    this.diarioService.findAll().subscribe({
+      next: lista => this.rowData = lista,
+      error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+    });
+  }
+
+  onGridReady(params: GridReadyEvent<DiarioBordo>) {
+    this.gridApi = params.api;
+    setTimeout(() => params.api.sizeColumnsToFit(), 50);
+  }
+}

--- a/frontend/src/app/components/diario-classe/diario-classe-form/diario-classe-form.component.html
+++ b/frontend/src/app/components/diario-classe/diario-classe-form/diario-classe-form.component.html
@@ -1,0 +1,24 @@
+<div class="container mt-3">
+  <form (ngSubmit)="save()" #form="ngForm">
+    <div class="mb-3">
+      <label class="form-label">Data</label>
+      <input mdbInput type="date" [(ngModel)]="diario.data" name="data" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Tipo</label>
+      <select class="form-select" [(ngModel)]="diario.tipo" name="tipo">
+        <option value="nota">Nota</option>
+        <option value="falta">Falta</option>
+      </select>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Valor</label>
+      <input mdbInput type="number" step="0.01" [(ngModel)]="diario.valor" name="valor" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Observação</label>
+      <textarea mdbInput [(ngModel)]="diario.observacao" name="observacao" class="form-control"></textarea>
+    </div>
+    <button mdbBtn type="submit" class="btn btn-primary">Salvar</button>
+  </form>
+</div>

--- a/frontend/src/app/components/diario-classe/diario-classe-form/diario-classe-form.component.ts
+++ b/frontend/src/app/components/diario-classe/diario-classe-form/diario-classe-form.component.ts
@@ -1,0 +1,58 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MdbFormsModule } from 'mdb-angular-ui-kit/forms';
+import { MdbRippleModule } from 'mdb-angular-ui-kit/ripple';
+import { ActivatedRoute, Router } from '@angular/router';
+import Swal from 'sweetalert2';
+import { DiarioClasseService } from '../../../services/diario-classe.service';
+import { DiarioClasse } from '../../../models/diario-classe';
+
+@Component({
+  selector: 'app-diario-classe-form',
+  standalone: true,
+  imports: [CommonModule, MdbFormsModule, MdbRippleModule, FormsModule],
+  templateUrl: './diario-classe-form.component.html'
+})
+export class DiarioClasseFormComponent {
+  diario: DiarioClasse = new DiarioClasse(null, '', null, '', null, null, null, null);
+  router = inject(ActivatedRoute);
+  router2 = inject(Router);
+  diarioService = inject(DiarioClasseService);
+
+  constructor() {
+    const id = this.router.snapshot.params['id'];
+    if (id) {
+      this.findById(id);
+    }
+  }
+
+  findById(id: number) {
+    this.diarioService.findById(id).subscribe({
+      next: d => this.diario = d,
+      error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+    });
+  }
+
+  save() {
+    if (this.diario.id) {
+      this.diarioService.update(this.diario).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Registro editado!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/diario-classe']);
+        },
+        error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+      });
+    } else {
+      const obj = { ...this.diario };
+      delete obj.id;
+      this.diarioService.save(obj).subscribe({
+        next: () => {
+          Swal.fire({ title: 'Registro cadastrado!', icon: 'success', confirmButtonText: 'Ok' });
+          this.router2.navigate(['admin/diario-classe']);
+        },
+        error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+      });
+    }
+  }
+}

--- a/frontend/src/app/components/diario-classe/diario-classe-list/diario-classe-list.component.html
+++ b/frontend/src/app/components/diario-classe/diario-classe-list/diario-classe-list.component.html
@@ -1,0 +1,10 @@
+<div class="container mt-3">
+  <ag-grid-angular
+    class="ag-theme-alpine"
+    [rowData]="rowData"
+    [columnDefs]="colDefs"
+    [defaultColDef]="defaultColDef"
+    [gridOptions]="gridOptions"
+    (gridReady)="onGridReady($event)">
+  </ag-grid-angular>
+</div>

--- a/frontend/src/app/components/diario-classe/diario-classe-list/diario-classe-list.component.ts
+++ b/frontend/src/app/components/diario-classe/diario-classe-list/diario-classe-list.component.ts
@@ -1,0 +1,53 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { AgGridModule } from 'ag-grid-angular';
+import { MdbRippleModule } from 'mdb-angular-ui-kit/ripple';
+import { ColDef, GridApi, GridOptions, GridReadyEvent } from 'ag-grid-community';
+import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
+import { DiarioClasse } from '../../../models/diario-classe';
+import { DiarioClasseService } from '../../../services/diario-classe.service';
+import Swal from 'sweetalert2';
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+@Component({
+  selector: 'app-diario-classe-list',
+  standalone: true,
+  imports: [CommonModule, AgGridModule, MdbRippleModule, RouterLink],
+  templateUrl: './diario-classe-list.component.html'
+})
+export class DiarioClasseListComponent {
+  private gridApi!: GridApi<DiarioClasse>;
+  public gridOptions: GridOptions<DiarioClasse> = {
+    pagination: true,
+    paginationPageSize: 20,
+    domLayout: 'autoHeight'
+  };
+
+  colDefs: ColDef<DiarioClasse>[] = [
+    { field: 'data', headerName: 'Data', valueFormatter: p => p.value ? new Date(p.value).toLocaleDateString('pt-BR') : '' },
+    { field: 'tipo', headerName: 'Tipo' },
+    { field: 'valor', headerName: 'Valor' },
+    { field: 'observacao', headerName: 'Observação' }
+  ];
+
+  defaultColDef: ColDef = { sortable: true, filter: true, resizable: true, flex: 1 };
+
+  rowData: DiarioClasse[] = [];
+  diarioService = inject(DiarioClasseService);
+
+  constructor() { this.findAll(); }
+
+  findAll() {
+    this.diarioService.findAll().subscribe({
+      next: lista => this.rowData = lista,
+      error: () => Swal.fire({ title: 'Ocorreu um erro!', icon: 'error', confirmButtonText: 'Ok' })
+    });
+  }
+
+  onGridReady(params: GridReadyEvent<DiarioClasse>) {
+    this.gridApi = params.api;
+    setTimeout(() => params.api.sizeColumnsToFit(), 50);
+  }
+}

--- a/frontend/src/app/models/diario-bordo.ts
+++ b/frontend/src/app/models/diario-bordo.ts
@@ -1,0 +1,28 @@
+import { Aluno } from './aluno';
+import { Turma } from './turmas';
+import { Professor } from './professor';
+
+export class DiarioBordo {
+  id?: number;
+  data: Date | null;
+  anotacao: string;
+  aluno: Aluno | null;
+  turma: Turma | null;
+  professor: Professor | null;
+
+  constructor(
+    data: Date | null,
+    anotacao: string,
+    aluno: Aluno | null,
+    turma: Turma | null,
+    professor: Professor | null,
+    id?: number
+  ) {
+    this.id = id;
+    this.data = data;
+    this.anotacao = anotacao;
+    this.aluno = aluno;
+    this.turma = turma;
+    this.professor = professor;
+  }
+}

--- a/frontend/src/app/models/diario-classe.ts
+++ b/frontend/src/app/models/diario-classe.ts
@@ -1,0 +1,38 @@
+import { Professor } from './professor';
+import { Turma } from './turmas';
+import { Disciplina } from './disciplina';
+import { Aluno } from './aluno';
+
+export class DiarioClasse {
+  id?: number;
+  data: Date | null;
+  tipo: string;
+  valor: number | null;
+  observacao: string;
+  professor: Professor | null;
+  turma: Turma | null;
+  disciplina: Disciplina | null;
+  aluno: Aluno | null;
+
+  constructor(
+    data: Date | null,
+    tipo: string,
+    valor: number | null,
+    observacao: string,
+    professor: Professor | null,
+    turma: Turma | null,
+    disciplina: Disciplina | null,
+    aluno: Aluno | null,
+    id?: number
+  ) {
+    this.id = id;
+    this.data = data;
+    this.tipo = tipo;
+    this.valor = valor;
+    this.observacao = observacao;
+    this.professor = professor;
+    this.turma = turma;
+    this.disciplina = disciplina;
+    this.aluno = aluno;
+  }
+}

--- a/frontend/src/app/services/diario-bordo.service.ts
+++ b/frontend/src/app/services/diario-bordo.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { DiarioBordo } from '../models/diario-bordo';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DiarioBordoService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/diarios-bordo';
+
+  findAll(): Observable<DiarioBordo[]> {
+    return this.http.get<DiarioBordo[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(diario: DiarioBordo): Observable<string> {
+    return this.http.post<string>(this.API + '/save', diario, { responseType: 'text' as 'json' });
+  }
+
+  update(diario: DiarioBordo): Observable<string> {
+    return this.http.put<string>(this.API + '/update', diario, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<DiarioBordo> {
+    return this.http.get<DiarioBordo>(this.API + '/findById/' + id);
+  }
+}

--- a/frontend/src/app/services/diario-classe.service.ts
+++ b/frontend/src/app/services/diario-classe.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { DiarioClasse } from '../models/diario-classe';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DiarioClasseService {
+  private readonly http = inject(HttpClient);
+  private readonly API = 'http://localhost:8080/diarios-classe';
+
+  findAll(): Observable<DiarioClasse[]> {
+    return this.http.get<DiarioClasse[]>(this.API + '/findAll');
+  }
+
+  delete(id: number): Observable<string> {
+    return this.http.delete<string>(this.API + '/delete/' + id, { responseType: 'text' as 'json' });
+  }
+
+  save(diario: DiarioClasse): Observable<string> {
+    return this.http.post<string>(this.API + '/save', diario, { responseType: 'text' as 'json' });
+  }
+
+  update(diario: DiarioClasse): Observable<string> {
+    return this.http.put<string>(this.API + '/update', diario, { responseType: 'text' as 'json' });
+  }
+
+  findById(id: number): Observable<DiarioClasse> {
+    return this.http.get<DiarioClasse>(this.API + '/findById/' + id);
+  }
+}


### PR DESCRIPTION
## Summary
- add `DiarioClasse` and `DiarioBordo` entities with relationships to students, teachers and classes
- create repositories, services and controllers for the new diaries
- expose new Angular routes and components to manage diary notes and class logs
- provide client-side services and models for diary handling

## Testing
- `mvn test` *(fails: mvn not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bccabac708320af2eaa5ea3119f1a